### PR TITLE
feat: Add support for Adjacency Matrix Aggregation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4075,6 +4075,74 @@ export class BucketAggregationBase extends Aggregation {
 }
 
 /**
+ * A bucket aggregation returning a form of adjacency matrix.
+ * The request provides a collection of named filter expressions,
+ * similar to the `filters` aggregation request. Each bucket in the response
+ * represents a non-empty cell in the matrix of intersecting filters.
+ *
+ * @param {string} name The name which will be used to refer to this aggregation.
+ *
+ * @extends BucketAggregationBase
+ */
+export class AdjacencyMatrixAggregation extends BucketAggregationBase {
+    constructor(name: string);
+
+    /**
+     * @override
+     * @throws {Error} This method cannot be called on AdjacencyMatrixAggregation
+     */
+    field(): never;
+
+    /**
+     * @override
+     * @throws {Error} This method cannot be called on AdjacencyMatrixAggregation
+     */
+    script(): never;
+
+    /**
+     * Sets a named filter query.
+     *
+     * @param {string} filterName Name for the filter.
+     * @param {Query} filterQuery Query to filter on. Example - term query.
+     * @throws {TypeError} If `filterQuery` is not an instance of `Query`
+     */
+    filter(filterName: string, filterQuery: Query): this;
+
+    /**
+     * Assigns filters to already added filters.
+     * Does not mix with anonymous filters.
+     * If anonymous filters are present, they will be overwritten.
+     *
+     * @param {Object} filterQueries Object with multiple key value pairs
+     * where filter name is the key and filter query is the value.
+     * @throws {TypeError} If `filterQueries` is not an instance of object
+     */
+    filters(filterQueries: object): this;
+
+    /**
+     * Sets the `separator` parameter to use a separator string other than
+     * the default of the ampersand.
+     *
+     * @param {string} sep the string used to separate keys in intersections buckets
+     * e.g. & character for keyed filters A and B would return an
+     * intersection bucket named A&B
+     */
+    separator(sep: string): this;
+}
+
+/**
+ * A bucket aggregation returning a form of adjacency matrix.
+ * The request provides a collection of named filter expressions,
+ * similar to the `filters` aggregation request. Each bucket in the response
+ * represents a non-empty cell in the matrix of intersecting filters.
+ *
+ * @param {string} name The name which will be used to refer to this aggregation.
+ *
+ * @extends BucketAggregationBase
+ */
+export function adjacencyMatrixAggregation(name: string): AdjacencyMatrixAggregation;
+
+/**
  * A special single bucket aggregation that enables aggregating
  * from buckets on parent document types to buckets on child documents.
  * This aggregation relies on the `_parent` field in the mapping.

--- a/roadmap.md
+++ b/roadmap.md
@@ -11,6 +11,6 @@
  - [x] Elasticsearch docs pull request
  - [x] Documentation examples
  - [x] Add an `index.d.ts` file for better intellisense - http://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html, https://github.com/Microsoft/TypeScript/issues/8335
- - [ ] Add Adjacency matrix Aggregation to Bucket Aggregations
+ - [x] Add Adjacency matrix Aggregation to Bucket Aggregations
  - [ ] Suggesters
  - [ ] Use ES6 modules

--- a/src/aggregations/bucket-aggregations/adjacency-matrix-aggregation.js
+++ b/src/aggregations/bucket-aggregations/adjacency-matrix-aggregation.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const has = require('lodash.has');
+
+const { Query, util: { checkType } } = require('../../core');
+
+const BucketAggregationBase = require('./bucket-aggregation-base');
+
+const ES_REF_URL =
+    'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-adjacency-matrix-aggregation.html';
+
+/**
+ * A bucket aggregation returning a form of adjacency matrix.
+ * The request provides a collection of named filter expressions,
+ * similar to the `filters` aggregation request. Each bucket in the response
+ * represents a non-empty cell in the matrix of intersecting filters.
+ *
+ * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-adjacency-matrix-aggregation.html)
+ *
+ * @example
+ * const agg = bob.adjacencyMatrixAggregation('interactions').filters({
+ *     grpA: bob.termsQuery('accounts', ['hillary', 'sidney']),
+ *     grpB: bob.termsQuery('accounts', ['donald', 'mitt']),
+ *     grpC: bob.termsQuery('accounts', ['vladimir', 'nigel'])
+ * });
+ *
+ * @param {string} name The name which will be used to refer to this aggregation.
+ *
+ * @extends BucketAggregationBase
+ */
+class AdjacencyMatrixAggregation extends BucketAggregationBase {
+    // eslint-disable-next-line require-jsdoc
+    constructor(name) {
+        super(name, 'adjacency_matrix');
+    }
+
+    /**
+     * @override
+     * @throws {Error} This method cannot be called on AdjacencyMatrixAggregation
+     */
+    field() {
+        console.log(`Please refer ${ES_REF_URL}`);
+        throw new Error('field is not supported in AdjacencyMatrixAggregation');
+    }
+
+    /**
+     * @override
+     * @throws {Error} This method cannot be called on AdjacencyMatrixAggregation
+     */
+    script() {
+        console.log(`Please refer ${ES_REF_URL}`);
+        throw new Error('script is not supported in AdjacencyMatrixAggregation');
+    }
+
+    /**
+     * Sets a named filter query.
+     *
+     * @param {string} filterName Name for the filter.
+     * @param {Query} filterQuery Query to filter on. Example - term query.
+     * @returns {AdjacencyMatrixAggregation} returns `this` so that calls can be chained
+     * @throws {TypeError} If `filterQuery` is not an instance of `Query`
+     */
+    filter(filterName, filterQuery) {
+        checkType(filterQuery, Query);
+
+        if (!has(this._aggsDef, 'filters')) this._aggsDef.filters = {};
+
+        this._aggsDef.filters[filterName] = filterQuery;
+        return this;
+    }
+
+    /**
+     * Assigns filters to already added filters.
+     * Does not mix with anonymous filters.
+     * If anonymous filters are present, they will be overwritten.
+     *
+     * @param {Object} filterQueries Object with multiple key value pairs
+     * where filter name is the key and filter query is the value.
+     * @returns {AdjacencyMatrixAggregation} returns `this` so that calls can be chained
+     * @throws {TypeError} If `filterQueries` is not an instance of object
+     */
+    filters(filterQueries) {
+        checkType(filterQueries, Object);
+
+        if (!has(this._aggsDef, 'filters')) this._aggsDef.filters = {};
+
+        Object.assign(this._aggsDef.filters, filterQueries);
+        return this;
+    }
+
+    /**
+     * Sets the `separator` parameter to use a separator string other than
+     * the default of the ampersand.
+     *
+     * @param {string} sep the string used to separate keys in intersections buckets
+     * e.g. & character for keyed filters A and B would return an
+     * intersection bucket named A&B
+     * @returns {AdjacencyMatrixAggregation} returns `this` so that calls can be chained
+     */
+    separator(sep) {
+        this._aggsDef.separator = sep;
+        return this;
+    }
+}
+
+module.exports = AdjacencyMatrixAggregation;

--- a/src/aggregations/bucket-aggregations/index.js
+++ b/src/aggregations/bucket-aggregations/index.js
@@ -5,6 +5,7 @@ exports.HistogramAggregationBase = require('./histogram-aggregation-base');
 exports.RangeAggregationBase = require('./range-aggregation-base');
 exports.TermsAggregationBase = require('./terms-aggregation-base');
 
+exports.AdjacencyMatrixAggregation = require('./adjacency-matrix-aggregation');
 exports.ChildrenAggregation = require('./children-aggregation');
 exports.DateHistogramAggregation = require('./date-histogram-aggregation');
 exports.DateRangeAggregation = require('./date-range-aggregation');

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,7 @@ const {
         ValueCountAggregation
     },
     bucketAggregations: {
+        AdjacencyMatrixAggregation,
         ChildrenAggregation,
         DateHistogramAggregation,
         DateRangeAggregation,
@@ -332,6 +333,9 @@ exports.valueCountAggregation = constructorWrapper(ValueCountAggregation);
 /* ============ ============ ============ */
 /* ========= Bucket Aggregations ======== */
 /* ============ ============ ============ */
+exports.AdjacencyMatrixAggregation = AdjacencyMatrixAggregation;
+exports.adjacencyMatrixAggregation = constructorWrapper(AdjacencyMatrixAggregation);
+
 exports.ChildrenAggregation = ChildrenAggregation;
 exports.childrenAggregation = constructorWrapper(ChildrenAggregation);
 

--- a/test/aggregations-test/adjacency-matrix-agg.test.js
+++ b/test/aggregations-test/adjacency-matrix-agg.test.js
@@ -1,0 +1,62 @@
+import test from 'ava';
+import { AdjacencyMatrixAggregation, termQuery } from '../../src';
+import { illegalCall, setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = () => new AdjacencyMatrixAggregation('my_adj_mat_agg');
+
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    aggsExpectStrategy('my_adj_mat_agg', 'adjacency_matrix')
+);
+
+const filterQryA = termQuery('user', 'kimchy');
+const filterQryB = termQuery('company', 'elastic');
+
+test(setsAggType, AdjacencyMatrixAggregation, 'adjacency_matrix');
+test(illegalCall, AdjacencyMatrixAggregation, 'field', 'my_agg');
+test(illegalCall, AdjacencyMatrixAggregation, 'script', 'my_agg');
+test(setsOption, 'separator', { param: '$' });
+
+test('filters are set', t => {
+    let value = getInstance()
+        .filter('user_kimchy', filterQryA)
+        .filter('company_elastic', filterQryB)
+        .toJSON();
+    const expected = {
+        my_adj_mat_agg: {
+            adjacency_matrix: {
+                filters: {
+                    user_kimchy: { term: { user: 'kimchy' } },
+                    company_elastic: { term: { company: 'elastic' } }
+                }
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+
+    value = getInstance()
+        .filters({
+            user_kimchy: filterQryA,
+            company_elastic: filterQryB
+        })
+        .toJSON();
+    t.deepEqual(value, expected);
+});
+
+test('filters are merged', t => {
+    const agg = getInstance().filters({ user_kimchy: filterQryA });
+    agg.filters({ company_elastic: filterQryB });
+
+    const value = agg.toJSON();
+    const expected = {
+        my_adj_mat_agg: {
+            adjacency_matrix: {
+                filters: {
+                    user_kimchy: { term: { user: 'kimchy' } },
+                    company_elastic: { term: { company: 'elastic' } }
+                }
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -213,6 +213,9 @@ test('aggregations are exported', t => {
     /* ============ ============ ============ */
     /* ========= Bucket Aggregations ======== */
     /* ============ ============ ============ */
+    t.truthy(bob.AdjacencyMatrixAggregation);
+    t.truthy(bob.adjacencyMatrixAggregation);
+
     t.truthy(bob.ChildrenAggregation);
     t.truthy(bob.childrenAggregation);
 


### PR DESCRIPTION
[Adjacency matrix aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-adjacency-matrix-aggregation.html) was added in elasticsearch 5.3. This PR adds support for the same.