### PR TITLE
Add support for Suggesters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Although there were [breaking changes](https://www.elastic.co/guide/en/elasticse
 all deprecated queries, features in 5.0 were avoided or not implemented.
 
 What's Included:
-  * [Request body search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html)
+  * [Request Body Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html)
   * [Queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
   * [Aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html)
+  * [Suggesters](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html)
   * [Search Template](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html)
 
 ## Install

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -138,6 +138,13 @@ toc:
   - RandomScoreFunction
   - FieldValueFactorFunction
   - DecayScoreFunction
+  - name: Suggesters
+  - Suggester
+  - AnalyzedSuggesterBase
+  - TermSuggester
+  - DirectGenerator
+  - PhaseSuggester
+  - CompletionSuggester
   - name: Miscellaneous
   - Highlight
   - Script

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,6 +3,13 @@ https://github.com/sudo-suhas/elastic-builder
 `elastic-builder` is a library for easily building elasticsearch request body for search.
 It implements the builder syntax for building complex queries combining queries and aggregations.
 
+What's Included:
+  * [Request Body Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html)
+  * [Queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
+  * [Aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html)
+  * [Suggesters](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html)
+  * [Search Template](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html)
+
 The complete library documentation is present here.
 
 There are two ways to use the classes for constructing queries:

--- a/src/core/consts.js
+++ b/src/core/consts.js
@@ -81,3 +81,15 @@ exports.GEO_SHAPE_TYPES = new Set([
 ]);
 
 exports.GEO_RELATION_SET = new Set(['WITHIN', 'CONTAINS', 'DISJOINT', 'INTERSECTS']);
+
+exports.SUGGEST_MODE_SET = new Set(['missing', 'popular', 'always']);
+
+exports.STRING_DISTANCE_SET = new Set([
+    'internal',
+    'damerau_levenshtein',
+    'levenstein',
+    'jarowinkler',
+    'ngram'
+]);
+
+exports.SMOOTHING_MODEL_SET = new Set(['stupid_backoff', 'laplace', 'linear_interpolation']);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -8,6 +8,8 @@ exports.Aggregation = require('./aggregation');
 
 exports.Query = require('./query');
 
+exports.Suggester = require('./suggester');
+
 exports.Script = require('./script');
 
 exports.Highlight = require('./highlight');

--- a/src/core/script.js
+++ b/src/core/script.js
@@ -61,7 +61,8 @@ class Script {
     }
 
     /**
-     * Print warning messages to not mix Geo Point representations
+     * Print warning messages to not mix `Script` source
+     *
      * @private
      */
     _checkMixedRepr() {
@@ -104,7 +105,7 @@ class Script {
     }
 
     /**
-     * Specify the `stored` script by `id` which will be retrieved from cluster state.
+     * Specify the `file` script by stored as a file in the scripts folder.
      *
      * @param {string} fileName The name of the script stored as a file in the scripts folder.
      * For script file `config/scripts/calculate-score.groovy`,

--- a/src/core/suggester.js
+++ b/src/core/suggester.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+
+const isEmpty = require('lodash.isempty');
+
+/**
+ * Base class implementation for all suggester types.
+ *
+ * **NOTE:** Instantiating this directly should not be required.
+ * However, if you wish to add a custom implementation for whatever reason,
+ * this class should be extended and used, as validation against the class
+ * type is present in various places.
+ *
+ * @param {string} suggesterType The type of suggester.
+ * Can be one of `term`, `phrase`, `completion`
+ * @param {string} name The name of the Suggester, an arbitrary identifier
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ *
+ * @throws {Error} if `name` is empty
+ * @throws {Error} if `suggesterType` is empty
+ */
+class Suggester {
+    // eslint-disable-next-line require-jsdoc
+    constructor(suggesterType, name, field) {
+        if (isEmpty(suggesterType)) throw new Error('Suggester `suggesterType` cannot be empty');
+        if (isEmpty(name)) throw new Error('Suggester `name` cannot be empty');
+
+        this.name = name;
+        this.suggesterType = suggesterType;
+
+        this._body = {};
+        this._opts = this._body[name] = {};
+        this._suggestOpts = this._opts[suggesterType] = {};
+
+        if (!isNil(field)) this._suggestOpts.field = field;
+    }
+
+    /**
+     * Sets field to fetch the candidate suggestions from. This is a required option
+     * that either needs to be set globally or per suggestion.
+     *
+     * @param {string} field a valid field name
+     * @returns {Suggester} returns `this` so that calls can be chained
+     */
+    field(field) {
+        this._suggestOpts.field = field;
+        return this;
+    }
+
+    /**
+     * Sets the number of suggestions to return (defaults to `5`).
+     *
+     * @param {number} size
+     * @returns {Suggester} returns `this` so that calls can be chained.
+     */
+    size(size) {
+        this._suggestOpts.size = size;
+        return this;
+    }
+
+    /**
+     * Override default `toJSON` to return DSL representation for the `suggester`
+     *
+     * @override
+     * @returns {Object} returns an Object which maps to the elasticsearch DSL
+     */
+    toJSON() {
+        return this._body;
+    }
+}
+
+module.exports = Suggester;

--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,13 @@ const {
     matrixAggregations: { MatrixStatsAggregation }
 } = require('./aggregations');
 
+const {
+    TermSuggester,
+    DirectGenerator,
+    PhraseSuggester,
+    CompletionSuggester
+} = require('./suggesters');
+
 const recipes = require('./recipes');
 
 exports.RequestBodySearch = RequestBodySearch;
@@ -440,7 +447,7 @@ exports.MatrixStatsAggregation = MatrixStatsAggregation;
 exports.matrixStatsAggregation = constructorWrapper(MatrixStatsAggregation);
 
 /* ============ ============ ============ */
-/* ========== Score Functions ===========  */
+/* ========== Score Functions =========== */
 /* ============ ============ ============ */
 exports.ScriptScoreFunction = ScriptScoreFunction;
 exports.scriptScoreFunction = constructorWrapper(ScriptScoreFunction);
@@ -456,6 +463,22 @@ exports.fieldValueFactorFunction = constructorWrapper(FieldValueFactorFunction);
 
 exports.DecayScoreFunction = DecayScoreFunction;
 exports.decayScoreFunction = constructorWrapper(DecayScoreFunction);
+
+/* ============ ============ ============ */
+/* ============= Suggesters ============= */
+/* ============ ============ ============ */
+
+exports.TermSuggester = TermSuggester;
+exports.termSuggester = constructorWrapper(TermSuggester);
+
+exports.DirectGenerator = DirectGenerator;
+exports.directGenerator = constructorWrapper(DirectGenerator);
+
+exports.PhraseSuggester = PhraseSuggester;
+exports.phraseSuggester = constructorWrapper(PhraseSuggester);
+
+exports.CompletionSuggester = CompletionSuggester;
+exports.completionSuggester = constructorWrapper(CompletionSuggester);
 
 /* ============ ============ ============ */
 /* ============== Recipes =============== */

--- a/src/suggesters/analyzed-suggester-base.js
+++ b/src/suggesters/analyzed-suggester-base.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+
+const { Suggester } = require('../core');
+
+/**
+ * The `AnalyzedSuggesterBase` provides support for common options used
+ * in `TermSuggester` and `PhraseSuggester`.
+ *
+ * **NOTE:** Instantiating this directly should not be required.
+ * However, if you wish to add a custom implementation for whatever reason,
+ * this class could be extended.
+ *
+ * @param {string} suggesterType The type of suggester.
+ * Can be one of `term`, `phrase`
+ * @param {string} name The name of the Suggester, an arbitrary identifier
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ * @param {string=} txt A string to get suggestions for.
+ *
+ * @throws {Error} if `name` is empty
+ * @throws {Error} if `suggesterType` is empty
+ *
+ * @extends Suggester
+ */
+class AnalyzedSuggesterBase extends Suggester {
+    // eslint-disable-next-line require-jsdoc
+    constructor(suggesterType, name, field, txt) {
+        super(suggesterType, name, field);
+
+        if (!isNil(txt)) this._opts.text = txt;
+    }
+
+    /**
+     * Sets the text to get suggestions for. If not set, the global
+     * suggestion text will be used.
+     *
+     * @param {string} txt A string to get suggestions for.
+     * @returns {AnalyzedSuggesterBase} returns `this` so that calls can be chained.
+     */
+    text(txt) {
+        this._opts.text = txt;
+        return this;
+    }
+
+    /**
+     * Sets the analyzer to analyse the suggest text with. Defaults to
+     * the search analyzer of the suggest field.
+     *
+     * @param {string} analyzer The analyzer to analyse the suggest text with.
+     * @returns {AnalyzedSuggesterBase} returns `this` so that calls can be chained.
+     */
+    analyzer(analyzer) {
+        this._suggestOpts.analyzer = analyzer;
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of suggestions to be retrieved from each individual shard.
+     * During the reduce phase only the top N suggestions are returned based on the `size`
+     * option. Defaults to the `size` option. Setting this to a value higher than the `size`
+     * can be useful in order to get a more accurate document frequency for spelling
+     * corrections at the cost of performance. Due to the fact that terms are partitioned
+     * amongst shards, the shard level document frequencies of spelling corrections
+     * may not be precise. Increasing this will make these document frequencies
+     * more precise.
+     *
+     * @param {number} size
+     * @returns {AnalyzedSuggesterBase} returns `this` so that calls can be chained.
+     */
+    shardSize(size) {
+        this._suggestOpts.shard_size = size;
+        return this;
+    }
+}
+
+module.exports = AnalyzedSuggesterBase;

--- a/src/suggesters/completion-suggester.js
+++ b/src/suggesters/completion-suggester.js
@@ -1,0 +1,283 @@
+'use strict';
+
+const isObject = require('lodash.isobject');
+const has = require('lodash.has');
+
+const { Suggester } = require('../core');
+
+/**
+ * Set given default value on object if key is not present.
+ *
+ * @param {Object} obj
+ * @param {string} key
+ * @param {*} value
+ */
+function setDefault(obj, key, value) {
+    if (!has(obj, key)) obj[key] = value;
+}
+
+/**
+ * The completion suggester provides auto-complete/search-as-you-type
+ * functionality. This is a navigational feature to guide users to relevant
+ * results as they are typing, improving search precision. It is not meant
+ * for spell correction or did-you-mean functionality like the term or
+ * phrase suggesters.
+ *
+ * Ideally, auto-complete functionality should be as fast as a user types to
+ * provide instant feedback relevant to what a user has already typed in.
+ * Hence, completion suggester is optimized for speed. The suggester uses
+ * data structures that enable fast lookups, but are costly to build
+ * and are stored in-memory.
+ *
+ * Elasticsearch reference
+ *   - [Completion Suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html)
+ *   - [Context Suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html)
+ *
+ * @example
+ * const suggest = bob.completionSuggester('song-suggest', 'suggest').prefix('nir');
+ *
+ * @example
+ * const suggest = new bob.CompletionSuggester('place_suggestion', 'suggest')
+ *     .prefix('tim')
+ *     .size(10)
+ *     .contexts('place_type', ['cafe', 'restaurants']);
+ *
+ * @param {string} name The name of the Suggester, an arbitrary identifier
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ *
+ * @throws {Error} if `name` is empty
+ *
+ * @extends Suggester
+ */
+class CompletionSuggester extends Suggester {
+    // eslint-disable-next-line require-jsdoc
+    constructor(name, field) {
+        super('completion', name, field);
+    }
+
+    /**
+     * Sets the `prefix` for the `CompletionSuggester` query.
+     *
+     * @param {string} prefix
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    prefix(prefix) {
+        this._opts.prefix = prefix;
+        return this;
+    }
+
+    /**
+     * Check that the object property `this._suggestOpts.fuzzy` is an object.
+     * Set empty object if required.
+     *
+     * @private
+     */
+    _checkFuzzy() {
+        if (!isObject(this._suggestOpts.fuzzy)) {
+            this._suggestOpts.fuzzy = {};
+        }
+    }
+
+    /**
+     * Sets the `fuzzy` parameter. Can be customised with specific fuzzy parameters.
+     *
+     * @param {boolean|Object=} fuzzy Enable/disable `fuzzy` using boolean or
+     * object(with params)
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    fuzzy(fuzzy = true) {
+        this._suggestOpts.fuzzy = fuzzy;
+        return this;
+    }
+
+    /**
+     * Sets the `fuzziness` parameter which is interpreted as a Levenshtein Edit Distance —
+     * the number of one character changes that need to be made to one string to make it
+     * the same as another string.
+     *
+     * @example
+     * const suggest = bob.completionSuggester('song-suggest', 'suggest')
+     *     .prefix('nor')
+     *     .fuzziness(2);
+     *
+     * @param {number|string} factor Can be specified either as a number, or the maximum
+     * number of edits, or as `AUTO` which generates an edit distance based on the length
+     * of the term.
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    fuzziness(factor) {
+        this._checkFuzzy();
+
+        this._suggestOpts.fuzzy.fuzziness = factor;
+        return this;
+    }
+
+    /**
+     * Transpositions (`ab` → `ba`) are allowed by default but can be disabled
+     * by setting `transpositions` to false.
+     *
+     * @param {boolean} enable
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    transpositions(enable) {
+        this._checkFuzzy();
+
+        this._suggestOpts.fuzzy.transpositions = enable;
+        return this;
+    }
+
+    /**
+     * Sets the minimum length of the input before fuzzy suggestions are returned,
+     * defaults 3
+     *
+     * @param {number} len Minimum length of the input before fuzzy suggestions
+     * are returned, defaults 3
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    minLength(len) {
+        this._checkFuzzy();
+
+        this._suggestOpts.fuzzy.min_length = len;
+        return this;
+    }
+
+    /**
+     * The number of initial characters which will not be "fuzzified".
+     * This helps to reduce the number of terms which must be examined. Defaults to `1`.
+     *
+     * @param {number} len Characters to skip fuzzy for. Defaults to `1`.
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    prefixLength(len) {
+        this._checkFuzzy();
+
+        this._suggestOpts.fuzzy.prefix_length = len;
+        return this;
+    }
+
+    /**
+     * If `true`, all measurements (like fuzzy edit distance, transpositions,
+     * and lengths) are measured in Unicode code points instead of in bytes.
+     * This is slightly slower than raw bytes, so it is set to `false` by default.
+     *
+     * @param {boolean} enable Measure in Unicode code points instead of in bytes.
+     * `false` by default.
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    unicodeAware(enable) {
+        this._checkFuzzy();
+
+        this._suggestOpts.fuzzy.unicode_aware = enable;
+        return this;
+    }
+
+    /**
+     * Sets the regular expression for completion suggester which supports regex queries.
+     *
+     * @example
+     * const suggest = bob.completionSuggester('song-suggest', 'suggest')
+     *     .regex('n[ever|i]r');
+     *
+     * @param {string} expr Regular expression
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    regex(expr) {
+        this._opts.regex = expr;
+        return this;
+    }
+
+    /**
+     * Set special flags. Possible flags are `ALL` (default),
+     * `ANYSTRING`, `COMPLEMENT`, `EMPTY`, `INTERSECTION`, `INTERVAL`, or `NONE`.
+     *
+     * @param {string} flags `|` separated flags. Possible flags are `ALL` (default),
+     * `ANYSTRING`, `COMPLEMENT`, `EMPTY`, `INTERSECTION`, `INTERVAL`, or `NONE`.
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    flags(flags) {
+        setDefault(this._suggestOpts, 'regex', {});
+
+        this._suggestOpts.regex.flags = flags;
+        return this;
+    }
+
+    /**
+     * Limit on how many automaton states regexp queries are allowed to create.
+     * This protects against too-difficult (e.g. exponentially hard) regexps.
+     * Defaults to 10000. You can raise this limit to allow more complex regular
+     * expressions to execute.
+     *
+     * @param {number} limit
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    maxDeterminizedStates(limit) {
+        setDefault(this._suggestOpts, 'regex', {});
+
+        this._suggestOpts.regex.max_determinized_states = limit;
+        return this;
+    }
+
+    /**
+     * The completion suggester considers all documents in the index, but it is often
+     * desirable to serve suggestions filtered and/or boosted by some criteria.
+     *
+     * To achieve suggestion filtering and/or boosting, you can add context mappings
+     * while configuring a completion field. You can define multiple context mappings
+     * for a completion field. Every context mapping has a unique name and a type.
+     *
+     * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html)
+     *
+     * @example
+     * const suggest = new bob.CompletionSuggester('place_suggestion', 'suggest')
+     *     .prefix('tim')
+     *     .size(10)
+     *     .contexts('place_type', [
+     *         { context: 'cafe' },
+     *         { context: 'restaurants', boost: 2 }
+     *     ]);
+     *
+     * @example
+     * // Suggestions can be filtered and boosted with respect to how close they
+     * // are to one or more geo points. The following filters suggestions that
+     * // fall within the area represented by the encoded geohash of a geo point:
+     * const suggest = new bob.CompletionSuggester('place_suggestion', 'suggest')
+     *     .prefix('tim')
+     *     .size(10)
+     *     .contexts('location', { lat: 43.662, lon: -79.38 });
+     *
+     * @example
+     * // Suggestions that are within an area represented by a geohash can also be
+     * // boosted higher than others
+     * const suggest = new bob.CompletionSuggester('place_suggestion', 'suggest')
+     *     .prefix('tim')
+     *     .size(10)
+     *     .contexts('location', [
+     *         {
+     *             lat: 43.6624803,
+     *             lon: -79.3863353,
+     *             precision: 2
+     *         },
+     *         {
+     *             context: {
+     *                 lat: 43.6624803,
+     *                 lon: -79.3863353
+     *             },
+     *             boost: 2
+     *         }
+     *     ]);
+     *
+     * @param {string} name
+     * @param {Array|Object} ctx
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    contexts(name, ctx) {
+        // This whole feature is bizzare!
+        // Not very happy with the implementation.
+        setDefault(this._suggestOpts, 'contexts', {});
+
+        this._suggestOpts.contexts[name] = ctx;
+        return this;
+    }
+}
+
+module.exports = CompletionSuggester;

--- a/src/suggesters/direct-generator.js
+++ b/src/suggesters/direct-generator.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+
+const { consts: { SUGGEST_MODE_SET }, util: { invalidParam } } = require('../core');
+
+const ES_REF_URL =
+    'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html#_direct_generators';
+
+const invalidSuggestModeParam = invalidParam(ES_REF_URL, 'suggest_mode', SUGGEST_MODE_SET);
+
+/**
+ * The `phrase` suggester uses candidate generators to produce a list of possible
+ * terms per term in the given text. A single candidate generator is similar
+ * to a `term` suggester called for each individual term in the text. The output
+ * of the generators is subsequently scored in combination with the candidates
+ * from the other terms to for suggestion candidates.
+ *
+ * The Phrase suggest API accepts a list of generators under the key `direct_generator`
+ * each of the generators in the list are called per term in the original text.
+ *
+ * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html#_direct_generators)
+ *
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ */
+class DirectGenerator {
+    // eslint-disable-next-line require-jsdoc
+    constructor(field) {
+        this._body = {};
+
+        if (!isNil(field)) this._body.field = field;
+    }
+
+    /**
+     * Sets field to fetch the candidate suggestions from. This is a required option
+     * that either needs to be set globally or per suggestion.
+     *
+     * @param {string} field a valid field name
+     * @returns {DirectGenerator} returns `this` so that calls can be chained
+     */
+    field(field) {
+        this._body.field = field;
+        return this;
+    }
+
+    /**
+     * Sets the number of suggestions to return (defaults to `5`).
+     *
+     * @param {number} size
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    size(size) {
+        this._body.size = size;
+        return this;
+    }
+
+    /**
+     * Sets the suggest mode which controls what suggestions are included
+     * or controls for what suggest text terms, suggestions should be suggested.
+     *  All values other than `always` can be thought of as an optimization to
+     * generate fewer suggestions to test on each shard and are not rechecked
+     * when combining the suggestions generated on each shard. Thus `missing`
+     * will generate suggestions for terms on shards that do not contain them
+     * even other shards do contain them. Those should be filtered out
+     * using `confidence`.
+     *
+     * Three possible values can be specified:
+     *   - `missing`: Only provide suggestions for suggest text terms that
+     *     are not in the index. This is the default.
+     *   - `popular`:  Only suggest suggestions that occur in more docs
+     *     than the original suggest text term.
+     *   - `always`: Suggest any matching suggestions based on terms in the suggest text.
+     *
+     * @param {string} mode Can be `missing`, `popular` or `always`
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     * @throws {Error} If `mode` is not one of `missing`, `popular` or `always`.
+     */
+    suggestMode(mode) {
+        if (isNil(mode)) invalidSuggestModeParam(mode);
+
+        const modeLower = mode.toLowerCase();
+        if (!SUGGEST_MODE_SET.has(modeLower)) {
+            invalidSuggestModeParam(mode);
+        }
+
+        this._body.suggest_mode = modeLower;
+        return this;
+    }
+
+    /**
+     * Sets the maximum edit distance candidate suggestions can have
+     * in order to be considered as a suggestion. Can only be a value
+     * between 1 and 2. Any other value result in an bad request
+     * error being thrown. Defaults to 2.
+     *
+     * @param {number} maxEdits Value between 1 and 2. Defaults to 2.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    maxEdits(maxEdits) {
+        this._body.max_edits = maxEdits;
+        return this;
+    }
+
+    /**
+     * Sets the number of minimal prefix characters that must match in order
+     * to be a candidate suggestions. Defaults to 1.
+     *
+     * Increasing this number improves spellcheck performance.
+     * Usually misspellings don't occur in the beginning of terms.
+     *
+     * @param {number} len The number of minimal prefix characters that must match in order
+     * to be a candidate suggestions. Defaults to 1.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    prefixLength(len) {
+        this._body.prefix_length = len;
+        return this;
+    }
+
+    /**
+     * Sets the minimum length a suggest text term must have in order to be included.
+     * Defaults to 4.
+     *
+     * @param {number} len The minimum length a suggest text term must have in order
+     * to be included. Defaults to 4.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    minWordLength(len) {
+        this._body.min_word_length = len;
+        return this;
+    }
+
+    /**
+     * Sets factor that is used to multiply with the `shards_size` in order to inspect
+     * more candidate spell corrections on the shard level.
+     * Can improve accuracy at the cost of performance. Defaults to 5.
+     *
+     * @param {number} maxInspections Factor used to multiple with `shards_size` in
+     * order to inspect more candidate spell corrections on the shard level.
+     * Defaults to 5
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    maxInspections(maxInspections) {
+        this._body.max_inspections = maxInspections;
+        return this;
+    }
+
+    /**
+     * Sets the minimal threshold in number of documents a suggestion should appear in.
+     * This can be specified as an absolute number or as a relative percentage of
+     * number of documents. This can improve quality by only suggesting high
+     * frequency terms. Defaults to 0f and is not enabled. If a value higher than 1
+     * is specified then the number cannot be fractional. The shard level document
+     * frequencies are used for this option.
+     *
+     * @param {number} limit Threshold in number of documents a suggestion
+     * should appear in. Defaults to 0f and is not enabled.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    minDocFreq(limit) {
+        this._body.min_doc_freq = limit;
+        return this;
+    }
+
+    /**
+     * Sets the maximum threshold in number of documents a suggest text token can
+     * exist in order to be included. Can be a relative percentage number (e.g 0.4)
+     * or an absolute number to represent document frequencies. If an value higher
+     * than 1 is specified then fractional can not be specified. Defaults to 0.01f.
+     * This can be used to exclude high frequency terms from being spellchecked.
+     * High frequency terms are usually spelled correctly on top of this also
+     * improves the spellcheck performance. The shard level document frequencies are
+     * used for this option.
+     *
+     * @param {number} limit Maximum threshold in number of documents a suggest text
+     * token can exist in order to be included. Defaults to 0.01f.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    maxTermFreq(limit) {
+        this._body.max_term_freq = limit;
+        return this;
+    }
+
+    /**
+     * Sets the filter (analyzer) that is applied to each of the tokens passed to this
+     * candidate generator. This filter is applied to the original token before
+     * candidates are generated.
+     *
+     * @param {string} filter a filter (analyzer) that is applied to each of the
+     * tokens passed to this candidate generator.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    preFilter(filter) {
+        this._body.pre_filter = filter;
+        return this;
+    }
+
+    /**
+     * Sets the filter (analyzer) that is applied to each of the generated tokens
+     * before they are passed to the actual phrase scorer.
+     *
+     * @param {string} filter a filter (analyzer) that is applied to each of the
+     * generated tokens before they are passed to the actual phrase scorer.
+     * @returns {DirectGenerator} returns `this` so that calls can be chained.
+     */
+    postFilter(filter) {
+        this._body.post_filter = filter;
+        return this;
+    }
+
+    /**
+     * Override default `toJSON` to return DSL representation for the `direct_generator`
+     *
+     * @override
+     * @returns {Object} returns an Object which maps to the elasticsearch DSL
+     */
+    toJSON() {
+        return this._body;
+    }
+}
+
+module.exports = DirectGenerator;

--- a/src/suggesters/index.js
+++ b/src/suggesters/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.AnalyzedSuggesterBase = require('./analyzed-suggester-base');
+
+exports.TermSuggester = require('./term-suggester');
+exports.DirectGenerator = require('./direct-generator');
+exports.PhraseSuggester = require('./phrase-suggester');
+exports.CompletionSuggester = require('./completion-suggester');

--- a/src/suggesters/phase-suggester.js
+++ b/src/suggesters/phase-suggester.js
@@ -1,0 +1,236 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+
+const { consts: { SMOOTHING_MODEL_SET }, util: { invalidParam } } = require('../core');
+
+const AnalyzedSuggesterBase = require('./analyzed-suggester-base');
+
+const ES_REF_URL =
+    'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html';
+
+const invalidSmoothingModeParam = invalidParam(ES_REF_URL, 'suggest_mode', SMOOTHING_MODEL_SET);
+
+/**
+ * The phrase suggester adds additional logic on top of the `term` suggester
+ * to select entire corrected phrases instead of individual tokens weighted
+ * based on `ngram-language` models. In practice this suggester will be able
+ * to make better decisions about which tokens to pick based on co-occurrence
+ * and frequencies.
+ *
+ * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html)
+ *
+ * @param {string} name The name of the Suggester, an arbitrary identifier
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ * @param {string=} txt A string to get suggestions for.
+ *
+ * @throws {Error} if `name` is empty
+ *
+ * @extends AnalyzedSuggesterBase
+ */
+class PhraseSuggester extends AnalyzedSuggesterBase {
+    // eslint-disable-next-line require-jsdoc
+    constructor(name, field, txt) {
+        super('phrase', name, field, txt);
+
+        this._collatePrune = null;
+    }
+
+    /**
+     * Sets max size of the n-grams (shingles) in the `field`. If the field
+     * doesn't contain n-grams (shingles) this should be omitted or set to `1`.
+     *
+     * Note: Elasticsearch tries to detect the gram size based on
+     * the specified `field`. If the field uses a `shingle` filter the `gram_size`
+     * is set to the `max_shingle_size` if not explicitly set.
+     * @param {number} size Max size of the n-grams (shingles) in the `field`.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    gramSize(size) {
+        this._opts.gram_size = size;
+        return this;
+    }
+
+    /**
+     * Sets the likelihood of a term being a misspelled even if the term exists
+     * in the dictionary. The default is `0.95` corresponding to 5% of the
+     * real words are misspelled.
+     *
+     * @param {number} factor Likelihood of a term being misspelled. Defaults to `0.95`
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    realWordErrorLikelihood(factor) {
+        this._opts.real_word_error_likelihood = factor;
+        return this;
+    }
+
+    /**
+     * Sets the confidence level defines a factor applied to the input phrases score
+     * which is used as a threshold for other suggest candidates. Only candidates
+     * that score higher than the threshold will be included in the result.
+     * For instance a confidence level of `1.0` will only return suggestions
+     * that score higher than the input phrase. If set to `0.0` the top N candidates
+     * are returned. The default is `1.0`.
+     *
+     * @param {number} level Factor applied to the input phrases score, used as
+     * a threshold for other suggest candidates.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    confidence(level) {
+        this._opts.confidence = level;
+        return this;
+    }
+
+    /**
+     * Sets the maximum percentage of the terms that at most considered to be
+     * misspellings in order to form a correction. This method accepts a float
+     * value in the range `[0..1)` as a fraction of the actual query terms or a
+     * number `>=1` as an absolute number of query terms. The default is set
+     * to `1.0` which corresponds to that only corrections with at most
+     * 1 misspelled term are returned. Note that setting this too high can
+     * negatively impact performance. Low values like 1 or 2 are recommended
+     * otherwise the time spend in suggest calls might exceed the time spend
+     * in query execution.
+     *
+     * @param {number} limit The maximum percentage of the terms that at most considered
+     * to be misspellings in order to form a correction.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    maxErrors(limit) {
+        this._opts.max_errors = limit;
+        return this;
+    }
+
+    /**
+     * Sets the separator that is used to separate terms in the bigram field.
+     * If not set the whitespace character is used as a separator.
+     *
+     * @param {string} sep The separator that is used to separate terms in the
+     * bigram field.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    separator(sep) {
+        this._opts.separator = sep;
+        return this;
+    }
+
+    /**
+     * Sets up suggestion highlighting. If not provided then no `highlighted` field
+     * is returned. If provided must contain exactly `pre_tag` and `post_tag` which
+     * are wrapped around the changed tokens. If multiple tokens in a row are changed
+     * the entire phrase of changed tokens is wrapped rather than each token.
+     *
+     * @param {string} preTag Pre-tag to wrap token
+     * @param {string} postTag Post-tag to wrap token
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    highlight(preTag, postTag) {
+        this._opts.highlight = { pre_tag: preTag, post_tag: postTag };
+        return this;
+    }
+
+    /**
+     * Checks each suggestion against the specified `query` to prune suggestions
+     * for which no matching docs exist in the index. The collate query for
+     * a suggestion is run only on the local shard from which the suggestion
+     * has been generated from. The `query` must be specified, and it is run
+     * as a [`template` query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-template-query.html).
+     *
+     * The current suggestion is automatically made available as the
+     * `{{suggestion}}` variable, which should be used in your query.
+     * Additionally, you can specify a `prune` to control if all phrase
+     * suggestions will be returned, when set to `true` the suggestions will
+     * have an additional option `collate_match`, which will be true if matching
+     * documents for the phrase was found, `false` otherwise. The default value
+     * for prune is `false`.
+     *
+     * @param {SearchTemplate} searchTempl The `query` to prune suggestions for which
+     * no matching docs exist in the index. It is specified as a `template` query.
+     * @param {boolean=} prune When set to `true`, the suggestions will
+     * have an additional option `collate_match`, which will be true if matching
+     * documents for the phrase was found, `false` otherwise. The default value
+     * for prune is `false`.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    collate(searchTempl, prune = null) {
+        // Add an instance check here?
+        this._opts.collate = searchTempl;
+        // Weird special case, prune needs to be introduces into
+        // the DSL repr for search template
+        this._collatePrune = prune;
+        return this;
+    }
+
+    /**
+     * Sets the smoothing model to balance weight between infrequent grams
+     * (grams (shingles) are not existing in the index) and frequent grams
+     * (appear at least once in the index).
+     *
+     * Three possible values can be specified:
+     *   - `stupid_backoff`: a simple backoff model that backs off to lower order
+     *     n-gram models if the higher order count is 0 and discounts the lower order
+     *     n-gram model by a constant factor. The default `discount` is `0.4`.
+     *     Stupid Backoff is the default model
+     *   - `laplace`: a smoothing model that uses an additive smoothing where a
+     *     constant (typically `1.0` or smaller) is added to all counts to balance weights,
+     *     The default `alpha` is `0.5`.
+     *   - `linear_interpolation`: a smoothing model that takes the weighted mean of the
+     *     unigrams, bigrams and trigrams based on user supplied weights (lambdas).
+     *     Linear Interpolation doesn’t have any default values.
+     *     All parameters (`trigram_lambda`, `bigram_lambda`, `unigram_lambda`)
+     *     must be supplied.
+     *
+     * @param {string} model One of `stupid_backoff`, `laplace`, `linear_interpolation`
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    smoothing(model) {
+        if (isNil(model)) invalidSmoothingModeParam(model);
+
+        const modelLower = model.toLowerCase();
+        if (!SMOOTHING_MODEL_SET.has(modelLower)) {
+            invalidSmoothingModeParam(model);
+        }
+
+        this._opts.suggest_mode = modelLower;
+        return this;
+    }
+
+    /**
+     * Sets the given list of candicate generators which produce a list of possible terms
+     * per term in the given text. Each of the generators in the list are
+     * called per term in the original text.
+     *
+     * The output of the generators is subsequently scored in combination with the
+     * candidates from the other terms to for suggestion candidates.
+     *
+     * @param {Array<DirectGenerator>|DirectGenerator} dirGen Array of `DirectGenerator`
+     * instances or a single instance of `DirectGenerator`
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    directGenerator(dirGen) {
+        // TODO: Do instance checks on `dirGen`
+        if (Array.isArray(dirGen)) {
+            this._opts.direct_generator = dirGen;
+        } else {
+            this._opts.direct_generator = [dirGen];
+        }
+
+        return this;
+    }
+
+    /**
+     * Override default `toJSON` to return DSL representation for the `phrase suggester`
+     *
+     * @override
+     * @returns {Object} returns an Object which maps to the elasticsearch DSL
+     */
+    toJSON() {
+        const json = super.toJSON();
+
+        if (!isNil(this._collatePrune)) json.collate.prune = this._collatePrune;
+
+        return json;
+    }
+}
+
+module.exports = PhraseSuggester;

--- a/src/suggesters/phrase-suggester.js
+++ b/src/suggesters/phrase-suggester.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+
+const { consts: { SMOOTHING_MODEL_SET }, util: { invalidParam } } = require('../core');
+
+const AnalyzedSuggesterBase = require('./analyzed-suggester-base');
+
+const ES_REF_URL =
+    'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html';
+
+const invalidSmoothingModeParam = invalidParam(ES_REF_URL, 'smoothing', SMOOTHING_MODEL_SET);
+
+/**
+ * The phrase suggester adds additional logic on top of the `term` suggester
+ * to select entire corrected phrases instead of individual tokens weighted
+ * based on `ngram-language` models. In practice this suggester will be able
+ * to make better decisions about which tokens to pick based on co-occurrence
+ * and frequencies.
+ *
+ * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html)
+ *
+ * @example
+ * const suggest = bob.phraseSuggester(
+ *     'simple_phrase',
+ *     'title.trigram',
+ *     'noble prize'
+ * )
+ *     .size(1)
+ *     .gramSize(3)
+ *     .directGenerator(bob.directGenerator('title.trigram').suggestMode('always'))
+ *     .highlight('<em>', '</em>');
+ *
+ * @param {string} name The name of the Suggester, an arbitrary identifier
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ * @param {string=} txt A string to get suggestions for.
+ *
+ * @throws {Error} if `name` is empty
+ *
+ * @extends AnalyzedSuggesterBase
+ */
+class PhraseSuggester extends AnalyzedSuggesterBase {
+    // eslint-disable-next-line require-jsdoc
+    constructor(name, field, txt) {
+        super('phrase', name, field, txt);
+    }
+
+    /**
+     * Sets max size of the n-grams (shingles) in the `field`. If the field
+     * doesn't contain n-grams (shingles) this should be omitted or set to `1`.
+     *
+     * Note: Elasticsearch tries to detect the gram size based on
+     * the specified `field`. If the field uses a `shingle` filter the `gram_size`
+     * is set to the `max_shingle_size` if not explicitly set.
+     * @param {number} size Max size of the n-grams (shingles) in the `field`.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    gramSize(size) {
+        this._suggestOpts.gram_size = size;
+        return this;
+    }
+
+    /**
+     * Sets the likelihood of a term being a misspelled even if the term exists
+     * in the dictionary. The default is `0.95` corresponding to 5% of the
+     * real words are misspelled.
+     *
+     * @param {number} factor Likelihood of a term being misspelled. Defaults to `0.95`
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    realWordErrorLikelihood(factor) {
+        this._suggestOpts.real_word_error_likelihood = factor;
+        return this;
+    }
+
+    /**
+     * Sets the confidence level defines a factor applied to the input phrases score
+     * which is used as a threshold for other suggest candidates. Only candidates
+     * that score higher than the threshold will be included in the result.
+     * For instance a confidence level of `1.0` will only return suggestions
+     * that score higher than the input phrase. If set to `0.0` the top N candidates
+     * are returned. The default is `1.0`.
+     *
+     * @param {number} level Factor applied to the input phrases score, used as
+     * a threshold for other suggest candidates.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    confidence(level) {
+        this._suggestOpts.confidence = level;
+        return this;
+    }
+
+    /**
+     * Sets the maximum percentage of the terms that at most considered to be
+     * misspellings in order to form a correction. This method accepts a float
+     * value in the range `[0..1)` as a fraction of the actual query terms or a
+     * number `>=1` as an absolute number of query terms. The default is set
+     * to `1.0` which corresponds to that only corrections with at most
+     * 1 misspelled term are returned. Note that setting this too high can
+     * negatively impact performance. Low values like 1 or 2 are recommended
+     * otherwise the time spend in suggest calls might exceed the time spend
+     * in query execution.
+     *
+     * @param {number} limit The maximum percentage of the terms that at most considered
+     * to be misspellings in order to form a correction.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    maxErrors(limit) {
+        this._suggestOpts.max_errors = limit;
+        return this;
+    }
+
+    /**
+     * Sets the separator that is used to separate terms in the bigram field.
+     * If not set the whitespace character is used as a separator.
+     *
+     * @param {string} sep The separator that is used to separate terms in the
+     * bigram field.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    separator(sep) {
+        this._suggestOpts.separator = sep;
+        return this;
+    }
+
+    /**
+     * Sets up suggestion highlighting. If not provided then no `highlighted` field
+     * is returned. If provided must contain exactly `pre_tag` and `post_tag` which
+     * are wrapped around the changed tokens. If multiple tokens in a row are changed
+     * the entire phrase of changed tokens is wrapped rather than each token.
+     *
+     * @param {string} preTag Pre-tag to wrap token
+     * @param {string} postTag Post-tag to wrap token
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    highlight(preTag, postTag) {
+        this._suggestOpts.highlight = { pre_tag: preTag, post_tag: postTag };
+        return this;
+    }
+
+    /**
+     * Checks each suggestion against the specified `query` to prune suggestions
+     * for which no matching docs exist in the index. The collate query for
+     * a suggestion is run only on the local shard from which the suggestion
+     * has been generated from. The `query` must be specified, and it is run
+     * as a [`template` query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-template-query.html).
+     *
+     * The current suggestion is automatically made available as the
+     * `{{suggestion}}` variable, which should be used in your query.
+     * Additionally, you can specify a `prune` to control if all phrase
+     * suggestions will be returned, when set to `true` the suggestions will
+     * have an additional option `collate_match`, which will be true if matching
+     * documents for the phrase was found, `false` otherwise. The default value
+     * for prune is `false`.
+     *
+     * @example
+     * const suggest = bob.phraseSuggester('simple_phrase', 'title.trigram')
+     *     .size(1)
+     *     .directGenerator(
+     *         bob.directGenerator('title.trigram')
+     *             .suggestMode('always')
+     *             .minWordLength(1)
+     *     )
+     *     .collate({
+     *         query: {
+     *             inline: {
+     *                 match: {
+     *                     '{{field_name}}': '{{suggestion}}'
+     *                 }
+     *             }
+     *         },
+     *         params: { field_name: 'title' },
+     *         prune: true
+     *     });
+     *
+     * @param {object} opts The options for `collate`. Can include the following:
+     *   - `query`: The `query` to prune suggestions for which
+     *      no matching docs exist in the index. It is run as a `template` query.
+     *   - `params`: The parameters to be passed to the template. The suggestion
+     *      value will be added to the variables you specify.
+     *   - `prune`: When set to `true`, the suggestions will
+     *      have an additional option `collate_match`, which will be true if matching
+     *      documents for the phrase was found, `false` otherwise. The default value
+     *      for prune is `false`.
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    collate(opts) {
+        // Add an instance check here?
+        // I wanted to use `SearchTemplate` here since the syntaqx is deceptively
+        // similar. But not quite the same.
+        // Adding a builder object called collate doesn't make sense either.
+        this._suggestOpts.collate = opts;
+        return this;
+    }
+
+    /**
+     * Sets the smoothing model to balance weight between infrequent grams
+     * (grams (shingles) are not existing in the index) and frequent grams
+     * (appear at least once in the index).
+     *
+     * Three possible values can be specified:
+     *   - `stupid_backoff`: a simple backoff model that backs off to lower order
+     *     n-gram models if the higher order count is 0 and discounts the lower order
+     *     n-gram model by a constant factor. The default `discount` is `0.4`.
+     *     Stupid Backoff is the default model
+     *   - `laplace`: a smoothing model that uses an additive smoothing where a
+     *     constant (typically `1.0` or smaller) is added to all counts to balance weights,
+     *     The default `alpha` is `0.5`.
+     *   - `linear_interpolation`: a smoothing model that takes the weighted mean of the
+     *     unigrams, bigrams and trigrams based on user supplied weights (lambdas).
+     *     Linear Interpolation doesn’t have any default values.
+     *     All parameters (`trigram_lambda`, `bigram_lambda`, `unigram_lambda`)
+     *     must be supplied.
+     *
+     * @param {string} model One of `stupid_backoff`, `laplace`, `linear_interpolation`
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    smoothing(model) {
+        if (isNil(model)) invalidSmoothingModeParam(model);
+
+        const modelLower = model.toLowerCase();
+        if (!SMOOTHING_MODEL_SET.has(modelLower)) {
+            invalidSmoothingModeParam(model);
+        }
+
+        this._suggestOpts.smoothing = modelLower;
+        return this;
+    }
+
+    /**
+     * Sets the given list of candicate generators which produce a list of possible terms
+     * per term in the given text. Each of the generators in the list are
+     * called per term in the original text.
+     *
+     * The output of the generators is subsequently scored in combination with the
+     * candidates from the other terms to for suggestion candidates.
+     *
+     * @example
+     * const suggest = bob.phraseSuggester('simple_phrase', 'title.trigram')
+     *     .size(1)
+     *     .directGenerator([
+     *         bob.directGenerator('title.trigram').suggestMode('always'),
+     *         bob.directGenerator('title.reverse')
+     *             .suggestMode('always')
+     *             .preFilter('reverse')
+     *             .postFilter('reverse')
+     *     ]);
+     *
+     * @param {Array<DirectGenerator>|DirectGenerator} dirGen Array of `DirectGenerator`
+     * instances or a single instance of `DirectGenerator`
+     * @returns {PhraseSuggester} returns `this` so that calls can be chained.
+     */
+    directGenerator(dirGen) {
+        // TODO: Do instance checks on `dirGen`
+        this._suggestOpts.direct_generator = Array.isArray(dirGen) ? dirGen : [dirGen];
+
+        return this;
+    }
+}
+
+module.exports = PhraseSuggester;

--- a/src/suggesters/term-suggester.js
+++ b/src/suggesters/term-suggester.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+
+const {
+    consts: { SUGGEST_MODE_SET, STRING_DISTANCE_SET },
+    util: { invalidParam }
+} = require('../core');
+
+const AnalyzedSuggesterBase = require('./analyzed-suggester-base');
+
+const ES_REF_URL =
+    'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html';
+
+const invalidSortParam = invalidParam(ES_REF_URL, 'sort', "'score' or 'frequency'");
+const invalidSuggestModeParam = invalidParam(ES_REF_URL, 'suggest_mode', SUGGEST_MODE_SET);
+const invalidStringDistanceParam = invalidParam(ES_REF_URL, 'string_distance', STRING_DISTANCE_SET);
+
+/**
+ * The term suggester suggests terms based on edit distance.
+ * The provided suggest text is analyzed before terms are suggested.
+ * The suggested terms are provided per analyzed suggest text token.
+ * The term suggester doesn’t take the query into account that is part of request.
+ *
+ * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html)
+ *
+ * @example
+ * const suggest = bob.termSuggester(
+ *     'my-suggestion',
+ *     'message',
+ *     'tring out Elasticsearch'
+ * );
+ *
+ * @param {string} name The name of the Suggester, an arbitrary identifier
+ * @param {string=} field The field to fetch the candidate suggestions from.
+ * @param {string=} txt A string to get suggestions for.
+ *
+ * @throws {Error} if `name` is empty
+ *
+ * @extends AnalyzedSuggesterBase
+ */
+class TermSuggester extends AnalyzedSuggesterBase {
+    // eslint-disable-next-line require-jsdoc
+    constructor(name, field, txt) {
+        super('term', name, field, txt);
+    }
+
+    /**
+     * Sets the sort to control how suggestions should be sorted per
+     * suggest text term.
+     *
+     * Two possible values:
+     *   - `score`: Sort by score first, then document frequency and
+     *     then the term itself.
+     *   - `frequency`: Sort by document frequency first, then similarity
+     *     score and then the term itself.
+     *
+     * @param {string} sort Can be `score` or `frequency`
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     * @throws {Error} If `sort` is neither `score` nor `frequency`.
+     */
+    sort(sort) {
+        if (isNil(sort)) invalidSortParam(sort);
+
+        const sortLower = sort.toLowerCase();
+        if (sortLower !== 'score' && sortLower !== 'frequency') {
+            invalidSortParam(sort);
+        }
+
+        this._suggestOpts.sort = sortLower;
+        return this;
+    }
+
+    /**
+     * Sets the suggest mode which controls what suggestions are included
+     * or controls for what suggest text terms, suggestions should be suggested.
+     *
+     * Three possible values can be specified:
+     *   - `missing`: Only provide suggestions for suggest text terms that
+     *     are not in the index. This is the default.
+     *   - `popular`:  Only suggest suggestions that occur in more docs
+     *     than the original suggest text term.
+     *   - `always`: Suggest any matching suggestions based on terms in the suggest text.
+     *
+     * @param {string} mode Can be `missing`, `popular` or `always`
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     * @throws {Error} If `mode` is not one of `missing`, `popular` or `always`.
+     */
+    suggestMode(mode) {
+        if (isNil(mode)) invalidSuggestModeParam(mode);
+
+        const modeLower = mode.toLowerCase();
+        if (!SUGGEST_MODE_SET.has(modeLower)) {
+            invalidSuggestModeParam(mode);
+        }
+
+        this._suggestOpts.suggest_mode = modeLower;
+        return this;
+    }
+
+    /**
+     * Sets the maximum edit distance candidate suggestions can have
+     * in order to be considered as a suggestion. Can only be a value
+     * between 1 and 2. Any other value result in an bad request
+     * error being thrown. Defaults to 2.
+     *
+     * @param {number} maxEdits Value between 1 and 2. Defaults to 2.
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     */
+    maxEdits(maxEdits) {
+        this._suggestOpts.max_edits = maxEdits;
+        return this;
+    }
+
+    /**
+     * Sets the number of minimal prefix characters that must match in order
+     * to be a candidate suggestions. Defaults to 1.
+     *
+     * Increasing this number improves spellcheck performance.
+     * Usually misspellings don't occur in the beginning of terms.
+     *
+     * @param {number} len The number of minimal prefix characters that must match in order
+     * to be a candidate suggestions. Defaults to 1.
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     */
+    prefixLength(len) {
+        this._suggestOpts.prefix_length = len;
+        return this;
+    }
+
+    /**
+     * Sets the minimum length a suggest text term must have in order to be included.
+     * Defaults to 4.
+     *
+     * @param {number} len The minimum length a suggest text term must have in order
+     * to be included. Defaults to 4.
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     */
+    minWordLength(len) {
+        this._suggestOpts.min_word_length = len;
+        return this;
+    }
+
+    /**
+     * Sets factor that is used to multiply with the `shards_size` in order to inspect
+     * more candidate spell corrections on the shard level.
+     * Can improve accuracy at the cost of performance. Defaults to 5.
+     *
+     * @param {number} maxInspections Factor used to multiple with `shards_size` in
+     * order to inspect more candidate spell corrections on the shard level.
+     * Defaults to 5
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     */
+    maxInspections(maxInspections) {
+        this._suggestOpts.max_inspections = maxInspections;
+        return this;
+    }
+
+    /**
+     * Sets the minimal threshold in number of documents a suggestion should appear in.
+     * This can be specified as an absolute number or as a relative percentage of
+     * number of documents. This can improve quality by only suggesting high
+     * frequency terms. Defaults to 0f and is not enabled. If a value higher than 1
+     * is specified then the number cannot be fractional. The shard level document
+     * frequencies are used for this option.
+     *
+     * @param {number} limit Threshold in number of documents a suggestion
+     * should appear in. Defaults to 0f and is not enabled.
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     */
+    minDocFreq(limit) {
+        this._suggestOpts.min_doc_freq = limit;
+        return this;
+    }
+
+    /**
+     * Sets the maximum threshold in number of documents a suggest text token can
+     * exist in order to be included. Can be a relative percentage number (e.g 0.4)
+     * or an absolute number to represent document frequencies. If an value higher
+     * than 1 is specified then fractional can not be specified. Defaults to 0.01f.
+     * This can be used to exclude high frequency terms from being spellchecked.
+     * High frequency terms are usually spelled correctly on top of this also
+     * improves the spellcheck performance. The shard level document frequencies are
+     * used for this option.
+     *
+     * @param {number} limit Maximum threshold in number of documents a suggest text
+     * token can exist in order to be included. Defaults to 0.01f.
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     */
+    maxTermFreq(limit) {
+        this._suggestOpts.max_term_freq = limit;
+        return this;
+    }
+
+    /**
+     * Sets the string distance implementation to use for comparing how similar
+     * suggested terms are.
+     *
+     * Five possible values can be specified:
+     *   - `internal`: The default based on `damerau_levenshtein` but highly optimized for
+     *     comparing string distance for terms inside the index.
+     *   - `damerau_levenshtein`: String distance algorithm based on Damerau-Levenshtein
+     *     algorithm.
+     *   - `levenstein`: String distance algorithm based on Levenstein edit distance
+     *     algorithm.
+     *   - `jarowinkler`: String distance algorithm based on Jaro-Winkler algorithm.
+     *   - `ngram`: String distance algorithm based on character n-grams.
+     *
+     * @param {string} implMethod One of `internal`, `damerau_levenshtein`, `levenstein`,
+     * `jarowinkler`, `ngram`
+     * @returns {TermSuggester} returns `this` so that calls can be chained.
+     * @throws {Error} If `implMethod` is not one of `internal`, `damerau_levenshtein`,
+     * `levenstein`, `jarowinkler` or ngram`.
+     */
+    stringDistance(implMethod) {
+        if (isNil(implMethod)) invalidStringDistanceParam(implMethod);
+
+        const implMethodLower = implMethod.toLowerCase();
+        if (!STRING_DISTANCE_SET.has(implMethodLower)) {
+            invalidStringDistanceParam(implMethod);
+        }
+
+        this._suggestOpts.string_distance = implMethodLower;
+        return this;
+    }
+}
+
+module.exports = TermSuggester;

--- a/test/_macros.js
+++ b/test/_macros.js
@@ -100,7 +100,7 @@ export function simpleExpect(keyName, propValue) {
  * @param {Object} defaultDef
  * @returns {function}
  */
-export function aggsExpectStrategy(name, type, defaultDef) {
+export function nameTypeExpectStrategy(name, type, defaultDef) {
     return (keyName, propValue) => ({
         [name]: {
             [type]: Object.assign({ [keyName]: propValue }, defaultDef)

--- a/test/aggregations-test/adjacency-matrix-agg.test.js
+++ b/test/aggregations-test/adjacency-matrix-agg.test.js
@@ -1,12 +1,12 @@
 import test from 'ava';
 import { AdjacencyMatrixAggregation, termQuery } from '../../src';
-import { illegalCall, setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { illegalCall, setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = () => new AdjacencyMatrixAggregation('my_adj_mat_agg');
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_adj_mat_agg', 'adjacency_matrix')
+    nameTypeExpectStrategy('my_adj_mat_agg', 'adjacency_matrix')
 );
 
 const filterQryA = termQuery('user', 'kimchy');

--- a/test/aggregations-test/bucket-agg-base.test.js
+++ b/test/aggregations-test/bucket-agg-base.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import { Script } from '../../src';
 import { BucketAggregationBase } from '../../src/aggregations/bucket-aggregations';
-import { illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { illegalParamType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) => new BucketAggregationBase('my_agg', 'my_type', ...args);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'my_type'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'my_type'));
 
 test('can be instantiated', t => {
     t.truthy(getInstance());

--- a/test/aggregations-test/bucket-script-agg.test.js
+++ b/test/aggregations-test/bucket-script-agg.test.js
@@ -1,10 +1,13 @@
 import test from 'ava';
 import { BucketScriptAggregation, Script } from '../../src';
-import { setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = bucketsPath => new BucketScriptAggregation('my_agg', bucketsPath);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'bucket_script'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'bucket_script')
+);
 
 test(setsAggType, BucketScriptAggregation, 'bucket_script');
 test(setsOption, 'script', { param: 'params.my_var1 / params.my_var2' });

--- a/test/aggregations-test/bucket-selector-agg.test.js
+++ b/test/aggregations-test/bucket-selector-agg.test.js
@@ -1,12 +1,12 @@
 import test from 'ava';
 import { BucketSelectorAggregation, Script } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = bucketsPath => new BucketSelectorAggregation('my_agg', bucketsPath);
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'bucket_selector')
+    nameTypeExpectStrategy('my_agg', 'bucket_selector')
 );
 
 test(setsAggType, BucketSelectorAggregation, 'bucket_selector');

--- a/test/aggregations-test/cardinality-agg.test.js
+++ b/test/aggregations-test/cardinality-agg.test.js
@@ -1,10 +1,13 @@
 import test from 'ava';
 import { CardinalityAggregation } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = field => new CardinalityAggregation('my_agg', field);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'cardinality'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'cardinality')
+);
 
 test(setsAggType, CardinalityAggregation, 'cardinality');
 test(illegalCall, CardinalityAggregation, 'format', 'my_agg');

--- a/test/aggregations-test/derivative-agg.test.js
+++ b/test/aggregations-test/derivative-agg.test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { DerivativeAggregation } from '../../src';
-import { setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = bucketsPath => new DerivativeAggregation('my_agg', bucketsPath);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'derivative'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'derivative'));
 
 test(setsAggType, DerivativeAggregation, 'derivative');
 test(setsOption, 'unit', { param: 'day' });

--- a/test/aggregations-test/diversified-sampler-agg.test.js
+++ b/test/aggregations-test/diversified-sampler-agg.test.js
@@ -3,7 +3,7 @@ import { DiversifiedSamplerAggregation } from '../../src';
 import {
     setsAggType,
     validatedCorrectly,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro
 } from '../_macros';
 
@@ -11,7 +11,7 @@ const getInstance = () => new DiversifiedSamplerAggregation('my_samples', 'my_fi
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_samples', 'diversified_sampler', {
+    nameTypeExpectStrategy('my_samples', 'diversified_sampler', {
         field: 'my_field'
     })
 );

--- a/test/aggregations-test/extended-stats-agg.test.js
+++ b/test/aggregations-test/extended-stats-agg.test.js
@@ -1,10 +1,13 @@
 import test from 'ava';
 import { ExtendedStatsAggregation } from '../../src';
-import { setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = field => new ExtendedStatsAggregation('my_agg', field);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'extended_stats'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'extended_stats')
+);
 
 test(setsAggType, ExtendedStatsAggregation, 'extended_stats');
 test(setsOption, 'sigma', { param: 3 });

--- a/test/aggregations-test/extended-stats-bucket-agg.test.js
+++ b/test/aggregations-test/extended-stats-bucket-agg.test.js
@@ -1,12 +1,12 @@
 import test from 'ava';
 import { ExtendedStatsBucketAggregation } from '../../src';
-import { setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = bucketsPath => new ExtendedStatsBucketAggregation('my_agg', bucketsPath);
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'extended_stats_bucket')
+    nameTypeExpectStrategy('my_agg', 'extended_stats_bucket')
 );
 
 test(setsAggType, ExtendedStatsBucketAggregation, 'extended_stats_bucket');

--- a/test/aggregations-test/filters-agg.test.js
+++ b/test/aggregations-test/filters-agg.test.js
@@ -5,7 +5,7 @@ import {
     illegalCall,
     illegalParamType,
     setsAggType,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro
 } from '../_macros';
 
@@ -13,7 +13,7 @@ const getInstance = (...args) => new FiltersAggregation('my_filters_agg', ...arg
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_filters_agg', 'filters')
+    nameTypeExpectStrategy('my_filters_agg', 'filters')
 );
 
 const filterQryA = termQuery('user', 'kimchy');

--- a/test/aggregations-test/geo-bounds-agg.test.js
+++ b/test/aggregations-test/geo-bounds-agg.test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { GeoBoundsAggregation } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = field => new GeoBoundsAggregation('my_agg', field);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'geo_bounds'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'geo_bounds'));
 
 test(setsAggType, GeoBoundsAggregation, 'geo_bounds');
 test(illegalCall, GeoBoundsAggregation, 'format', 'my_agg');

--- a/test/aggregations-test/geo-distance-agg.test.js
+++ b/test/aggregations-test/geo-distance-agg.test.js
@@ -3,7 +3,7 @@ import { GeoDistanceAggregation, geoPoint } from '../../src';
 import {
     illegalCall,
     illegalParamType,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro,
     validatedCorrectly
 } from '../_macros';
@@ -13,7 +13,7 @@ const getInstance = () => new GeoDistanceAggregation('my_geo_agg').range({ to: 1
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_geo_agg', 'geo_distance', {
+    nameTypeExpectStrategy('my_geo_agg', 'geo_distance', {
         ranges: [{ to: 100 }]
     })
 );

--- a/test/aggregations-test/geo-hash-grid-agg.test.js
+++ b/test/aggregations-test/geo-hash-grid-agg.test.js
@@ -1,12 +1,12 @@
 import test from 'ava';
 import { GeoHashGridAggregation } from '../../src';
-import { illegalCall, setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { illegalCall, setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = () => new GeoHashGridAggregation('my_geo_agg');
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_geo_agg', 'geohash_grid')
+    nameTypeExpectStrategy('my_geo_agg', 'geohash_grid')
 );
 
 test(setsAggType, GeoHashGridAggregation, 'geohash_grid');

--- a/test/aggregations-test/histogram-agg-base.test.js
+++ b/test/aggregations-test/histogram-agg-base.test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { HistogramAggregationBase } from '../../src/aggregations/bucket-aggregations';
-import { aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) => new HistogramAggregationBase('my_agg', 'my_type', ...args);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'my_type'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'my_type'));
 
 test(setsOption, 'interval', { param: 'year' });
 test(setsOption, 'format', { param: '####.00' });

--- a/test/aggregations-test/matrix-stats-agg.test.js
+++ b/test/aggregations-test/matrix-stats-agg.test.js
@@ -1,10 +1,18 @@
 import test from 'ava';
 import { MatrixStatsAggregation } from '../../src';
-import { setsAggType, illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import {
+    setsAggType,
+    illegalParamType,
+    nameTypeExpectStrategy,
+    makeSetsOptionMacro
+} from '../_macros';
 
 const getInstance = fields => new MatrixStatsAggregation('my_agg', fields);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'matrix_stats'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'matrix_stats')
+);
 
 test(setsAggType, MatrixStatsAggregation, 'matrix_stats');
 test(illegalParamType, getInstance(), 'fields', 'Array');

--- a/test/aggregations-test/metrics-agg-base.test.js
+++ b/test/aggregations-test/metrics-agg-base.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import { Script } from '../../src';
 import { MetricsAggregationBase } from '../../src/aggregations/metrics-aggregations';
-import { illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { illegalParamType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = field => new MetricsAggregationBase('my_agg', 'my_type', field);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'my_type'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'my_type'));
 
 test('can be instantiated', t => {
     t.truthy(getInstance());

--- a/test/aggregations-test/moving-average-agg.test.js
+++ b/test/aggregations-test/moving-average-agg.test.js
@@ -4,13 +4,13 @@ import {
     setsAggType,
     illegalCall,
     validatedCorrectly,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro
 } from '../_macros';
 
 const getInstance = bucketsPath => new MovingAverageAggregation('my_agg', bucketsPath);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'moving_avg'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'moving_avg'));
 
 test(setsAggType, MovingAverageAggregation, 'moving_avg');
 test(illegalCall, MovingAverageAggregation, 'format', 'my_agg');

--- a/test/aggregations-test/nested-agg.test.js
+++ b/test/aggregations-test/nested-agg.test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { NestedAggregation } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) => new NestedAggregation('my_agg', ...args);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'nested'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'nested'));
 
 test(setsAggType, NestedAggregation, 'nested');
 test(illegalCall, NestedAggregation, 'field', 'my_agg');

--- a/test/aggregations-test/percentile-ranks-agg.test.js
+++ b/test/aggregations-test/percentile-ranks-agg.test.js
@@ -4,7 +4,7 @@ import {
     setsAggType,
     illegalCall,
     illegalParamType,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro
 } from '../_macros';
 
@@ -12,7 +12,7 @@ const getInstance = (field, values) => new PercentileRanksAggregation('my_agg', 
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'percentile_ranks')
+    nameTypeExpectStrategy('my_agg', 'percentile_ranks')
 );
 
 test(setsAggType, PercentileRanksAggregation, 'percentile_ranks');

--- a/test/aggregations-test/percentiles-agg.test.js
+++ b/test/aggregations-test/percentiles-agg.test.js
@@ -1,10 +1,18 @@
 import test from 'ava';
 import { PercentilesAggregation } from '../../src';
-import { setsAggType, illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import {
+    setsAggType,
+    illegalParamType,
+    nameTypeExpectStrategy,
+    makeSetsOptionMacro
+} from '../_macros';
 
 const getInstance = field => new PercentilesAggregation('my_agg', field);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'percentiles'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'percentiles')
+);
 
 test(setsAggType, PercentilesAggregation, 'percentiles');
 test(illegalParamType, getInstance(), 'percents', 'Array');

--- a/test/aggregations-test/percentiles-bucket-agg.test.js
+++ b/test/aggregations-test/percentiles-bucket-agg.test.js
@@ -1,12 +1,17 @@
 import test from 'ava';
 import { PercentilesBucketAggregation } from '../../src';
-import { setsAggType, illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import {
+    setsAggType,
+    illegalParamType,
+    nameTypeExpectStrategy,
+    makeSetsOptionMacro
+} from '../_macros';
 
 const getInstance = bucketsPath => new PercentilesBucketAggregation('my_agg', bucketsPath);
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'percentiles_bucket')
+    nameTypeExpectStrategy('my_agg', 'percentiles_bucket')
 );
 
 test(setsAggType, PercentilesBucketAggregation, 'percentiles_bucket');

--- a/test/aggregations-test/pipeline-agg-base.test.js
+++ b/test/aggregations-test/pipeline-agg-base.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import { PipelineAggregationBase } from '../../src/aggregations/pipeline-aggregations';
-import { validatedCorrectly, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { validatedCorrectly, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = bucketsPath =>
     new PipelineAggregationBase('my_agg', 'my_type', '', bucketsPath);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'my_type'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'my_type'));
 
 test(validatedCorrectly, getInstance, 'gapPolicy', ['skip', 'insert_zeros']);
 test(setsOption, 'bucketsPath', { param: 'my_buckets_path' });

--- a/test/aggregations-test/range-agg-base.test.js
+++ b/test/aggregations-test/range-agg-base.test.js
@@ -1,13 +1,13 @@
 import test from 'ava';
 import { RangeAggregationBase } from '../../src/aggregations/bucket-aggregations';
-import { illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { illegalParamType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) =>
     new RangeAggregationBase('my_agg', 'my_type', ...args).range({ from: 10, to: 20 });
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'my_type', {
+    nameTypeExpectStrategy('my_agg', 'my_type', {
         ranges: [{ from: 10, to: 20 }]
     })
 );

--- a/test/aggregations-test/reverse-nested-agg.test.js
+++ b/test/aggregations-test/reverse-nested-agg.test.js
@@ -1,10 +1,13 @@
 import test from 'ava';
 import { ReverseNestedAggregation } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) => new ReverseNestedAggregation('my_agg', ...args);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'reverse_nested'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'reverse_nested')
+);
 
 test(setsAggType, ReverseNestedAggregation, 'reverse_nested');
 test(illegalCall, ReverseNestedAggregation, 'field', 'my_agg');

--- a/test/aggregations-test/sampler-agg.test.js
+++ b/test/aggregations-test/sampler-agg.test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { SamplerAggregation } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) => new SamplerAggregation('my_agg', ...args);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'sampler'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'sampler'));
 
 test(setsAggType, SamplerAggregation, 'sampler');
 test(illegalCall, SamplerAggregation, 'field', 'my_agg');

--- a/test/aggregations-test/scripted-metric-agg.test.js
+++ b/test/aggregations-test/scripted-metric-agg.test.js
@@ -1,12 +1,12 @@
 import test from 'ava';
 import { ScriptedMetricAggregation } from '../../src';
-import { setsAggType, illegalCall, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, illegalCall, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = () => new ScriptedMetricAggregation('my_agg');
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'scripted_metric')
+    nameTypeExpectStrategy('my_agg', 'scripted_metric')
 );
 
 test(setsAggType, ScriptedMetricAggregation, 'scripted_metric');

--- a/test/aggregations-test/serial-differencing-agg.test.js
+++ b/test/aggregations-test/serial-differencing-agg.test.js
@@ -1,10 +1,13 @@
 import test from 'ava';
 import { SerialDifferencingAggregation } from '../../src';
-import { setsAggType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { setsAggType, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = bucketsPath => new SerialDifferencingAggregation('my_agg', bucketsPath);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'serial_diff'));
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_agg', 'serial_diff')
+);
 
 test(setsAggType, SerialDifferencingAggregation, 'serial_diff');
 test(setsOption, 'lag', { param: 2 });

--- a/test/aggregations-test/significant-terms-agg.test.js
+++ b/test/aggregations-test/significant-terms-agg.test.js
@@ -1,12 +1,17 @@
 import test from 'ava';
 import { SignificantTermsAggregation, TermQuery, Script } from '../../src';
-import { setsAggType, illegalParamType, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import {
+    setsAggType,
+    illegalParamType,
+    nameTypeExpectStrategy,
+    makeSetsOptionMacro
+} from '../_macros';
 
 const getInstance = (...args) => new SignificantTermsAggregation('my_agg', ...args);
 
 const setsOption = makeSetsOptionMacro(
     getInstance,
-    aggsExpectStrategy('my_agg', 'significant_terms')
+    nameTypeExpectStrategy('my_agg', 'significant_terms')
 );
 
 const script = new Script().lang('groovy').file('calculate-score').params({ my_modifier: 2 });

--- a/test/aggregations-test/terms-agg-base.test.js
+++ b/test/aggregations-test/terms-agg-base.test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { TermsAggregationBase } from '../../src/aggregations/bucket-aggregations';
-import { validatedCorrectly, aggsExpectStrategy, makeSetsOptionMacro } from '../_macros';
+import { validatedCorrectly, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
 
 const getInstance = (...args) => new TermsAggregationBase('my_agg', 'my_type', '', ...args);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'my_type'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'my_type'));
 
 test(validatedCorrectly, getInstance, 'executionHint', [
     'map',

--- a/test/aggregations-test/terms-agg.test.js
+++ b/test/aggregations-test/terms-agg.test.js
@@ -3,13 +3,13 @@ import { TermsAggregation } from '../../src';
 import {
     setsAggType,
     validatedCorrectly,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro
 } from '../_macros';
 
 const getInstance = field => new TermsAggregation('my_agg', field);
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'terms'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'terms'));
 
 test(setsAggType, TermsAggregation, 'terms');
 test(validatedCorrectly, getInstance, 'collectMode', ['depth_first', 'breadth_first']);

--- a/test/aggregations-test/top-hits-agg.test.js
+++ b/test/aggregations-test/top-hits-agg.test.js
@@ -4,13 +4,13 @@ import {
     setsAggType,
     illegalCall,
     illegalParamType,
-    aggsExpectStrategy,
+    nameTypeExpectStrategy,
     makeSetsOptionMacro
 } from '../_macros';
 
 const getInstance = () => new TopHitsAggregation('my_agg');
 
-const setsOption = makeSetsOptionMacro(getInstance, aggsExpectStrategy('my_agg', 'top_hits'));
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_agg', 'top_hits'));
 
 const sortChannel = new Sort('channel', 'desc');
 const sortCategories = new Sort('categories', 'desc');

--- a/test/core-test/request-body-search.test.js
+++ b/test/core-test/request-body-search.test.js
@@ -8,6 +8,7 @@ import {
     BoolQuery,
     FunctionScoreQuery,
     TermsAggregation,
+    TermSuggester,
     ScriptScoreFunction,
     Sort,
     Script,
@@ -26,6 +27,8 @@ const filterQry = new BoolQuery()
 
 const aggA = new TermsAggregation('user_term_agg', 'user');
 const aggB = new TermsAggregation('keyword_term_agg', 'keyword');
+
+const suggest = new TermSuggester('my-suggestion', 'message', 'tring out Elasticsearch');
 
 const sortChannel = new Sort('channel', 'desc');
 const sortCategories = new Sort('categories', 'desc');
@@ -54,6 +57,7 @@ const instance = new RequestBodySearch();
 test(illegalParamType, instance, 'query', 'Query');
 test(illegalParamType, instance, 'aggregation', 'Aggregation');
 test(illegalParamType, instance, 'agg', 'Aggregation');
+test(illegalParamType, instance, 'suggest', 'Suggester');
 test(illegalParamType, instance, 'sort', 'Sort');
 test(illegalParamType, instance, 'scriptFields', 'Object');
 test(illegalParamType, instance, 'highlight', 'Highlight');
@@ -62,6 +66,12 @@ test(illegalParamType, instance, 'postFilter', 'Query');
 test(setsOption, 'query', { param: searchQry });
 test(setsOption, 'aggregation', { param: aggA, keyName: 'aggs' });
 test(setsOption, 'agg', { param: aggA, keyName: 'aggs' });
+test(setsOption, 'suggest', { param: suggest });
+test(setsOption, 'suggestText', {
+    param: 'suggest-text',
+    keyName: 'suggest',
+    propValue: { text: 'suggest-text' }
+});
 test(setsOption, 'timeout', { param: '5s' });
 test(setsOption, 'from', { param: 10 });
 test(setsOption, 'size', { param: 10 });

--- a/test/core-test/suggester.test.js
+++ b/test/core-test/suggester.test.js
@@ -1,0 +1,43 @@
+import test from 'ava';
+import { Suggester } from '../../src/core';
+import { nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = field => new Suggester('my_type', 'my_suggester', field);
+
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_suggester', 'my_type')
+);
+
+test('aggType cannot be empty', t => {
+    const err = t.throws(() => new Suggester());
+    t.is(err.message, 'Suggester `suggesterType` cannot be empty');
+});
+
+test('name cannot be empty', t => {
+    const err = t.throws(() => new Suggester('my_type'));
+    t.is(err.message, 'Suggester `name` cannot be empty');
+});
+
+test('can be instantiated', t => {
+    const value = getInstance().toJSON();
+    const expected = {
+        my_suggester: {
+            my_type: {}
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test('constructor sets field', t => {
+    const value = getInstance('my_field').toJSON();
+    const expected = {
+        my_suggester: {
+            my_type: { field: 'my_field' }
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test(setsOption, 'field', { param: 'my_field' });
+test(setsOption, 'size', { param: 5 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -319,6 +319,20 @@ test('aggregations are exported', t => {
     t.truthy(bob.matrixStatsAggregation);
 });
 
+test('suggesters are exported', t => {
+    t.truthy(bob.TermSuggester);
+    t.truthy(bob.termSuggester);
+
+    t.truthy(bob.DirectGenerator);
+    t.truthy(bob.directGenerator);
+
+    t.truthy(bob.PhraseSuggester);
+    t.truthy(bob.phraseSuggester);
+
+    t.truthy(bob.CompletionSuggester);
+    t.truthy(bob.completionSuggester);
+});
+
 test('score functions are exported', t => {
     /* ============ ============ ============ */
     /* ========== Score Functions =========== */

--- a/test/suggesters-test/analyzed-suggester-base.test.js
+++ b/test/suggesters-test/analyzed-suggester-base.test.js
@@ -1,0 +1,37 @@
+import test from 'ava';
+import { AnalyzedSuggesterBase } from '../../src/suggesters';
+import { nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = (...args) => new AnalyzedSuggesterBase('my_type', 'my_suggester', ...args);
+
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_suggester', 'my_type')
+);
+
+test('constructor sets txt', t => {
+    const value = getInstance('my_field', 'my-text').toJSON();
+    const expected = {
+        my_suggester: {
+            text: 'my-text',
+            my_type: {
+                field: 'my_field'
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test('text can be set', t => {
+    const value = getInstance().text('my-text').toJSON();
+    const expected = {
+        my_suggester: {
+            text: 'my-text',
+            my_type: {}
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test(setsOption, 'analyzer', { param: 'snowball' });
+test(setsOption, 'shardSize', { param: 10 });

--- a/test/suggesters-test/completion-suggester.test.js
+++ b/test/suggesters-test/completion-suggester.test.js
@@ -1,0 +1,95 @@
+import test from 'ava';
+import { CompletionSuggester } from '../../src';
+import { nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = () => new CompletionSuggester('my_suggester');
+
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_suggester', 'completion')
+);
+
+test('prefix is set', t => {
+    const value = getInstance().prefix('nir').toJSON();
+    const expected = {
+        my_suggester: {
+            prefix: 'nir',
+            completion: {}
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test(setsOption, 'fuzzy', { param: true });
+test(setsOption, 'fuzzy', { propValue: true });
+test(setsOption, 'fuzziness', { param: 2, keyName: 'fuzzy', propValue: { fuzziness: 2 } });
+test(setsOption, 'transpositions', {
+    param: true,
+    keyName: 'fuzzy',
+    propValue: { transpositions: true }
+});
+test(setsOption, 'minLength', { param: 2, keyName: 'fuzzy', propValue: { min_length: 2 } });
+test(setsOption, 'prefixLength', { param: 2, keyName: 'fuzzy', propValue: { prefix_length: 2 } });
+test(setsOption, 'fuzziness', { param: 2, keyName: 'fuzzy', propValue: { fuzziness: 2 } });
+test(setsOption, 'unicodeAware', {
+    param: true,
+    keyName: 'fuzzy',
+    propValue: { unicode_aware: true }
+});
+test('regex is set', t => {
+    const value = getInstance().regex('nir').toJSON();
+    const expected = {
+        my_suggester: {
+            regex: 'nir',
+            completion: {}
+        }
+    };
+    t.deepEqual(value, expected);
+});
+test(setsOption, 'flags', {
+    param: 'ANYSTRING',
+    keyName: 'regex',
+    propValue: { flags: 'ANYSTRING' }
+});
+test(setsOption, 'maxDeterminizedStates', {
+    param: 5000,
+    keyName: 'regex',
+    propValue: { max_determinized_states: 5000 }
+});
+test(setsOption, 'contexts', {
+    param: ['location', { lat: 43.662, lon: -79.38 }],
+    propValue: { location: { lat: 43.662, lon: -79.38 } }
+});
+
+test('multiple contexts can be set', t => {
+    const value = getInstance()
+        .contexts('location', { lat: 43.662, lon: -79.38 })
+        .contexts('place_type', ['cafe', 'restaurants'])
+        .toJSON();
+    const expected = {
+        my_suggester: {
+            completion: {
+                contexts: {
+                    location: { lat: 43.662, lon: -79.38 },
+                    place_type: ['cafe', 'restaurants']
+                }
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test('multiple fuzzy options can be set', t => {
+    const value = getInstance().fuzziness(2).transpositions(true).toJSON();
+    const expected = {
+        my_suggester: {
+            completion: {
+                fuzzy: {
+                    fuzziness: 2,
+                    transpositions: true
+                }
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+});

--- a/test/suggesters-test/direct-generator.test.js
+++ b/test/suggesters-test/direct-generator.test.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+import { DirectGenerator } from '../../src';
+import { validatedCorrectly, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = field => new DirectGenerator(field);
+
+const setsOption = makeSetsOptionMacro(getInstance);
+
+test('constructor sets field', t => {
+    const value = getInstance('my_field').toJSON();
+    const expected = {
+        field: 'my_field'
+    };
+    t.deepEqual(value, expected);
+});
+
+test(validatedCorrectly, getInstance, 'suggestMode', ['missing', 'popular', 'always']);
+
+test(setsOption, 'field', { param: 'my_field' });
+test(setsOption, 'size', { param: 7 });
+test(setsOption, 'suggestMode', { param: 'always' });
+test(setsOption, 'maxEdits', { param: 3 });
+test(setsOption, 'prefixLength', { param: 3 });
+test(setsOption, 'minWordLength', { param: 5 });
+test(setsOption, 'maxInspections', { param: 4 });
+test(setsOption, 'minDocFreq', { param: 0.4 });
+test(setsOption, 'maxTermFreq', { param: 1 });
+test(setsOption, 'preFilter', { param: 'reverse' });
+test(setsOption, 'postFilter', { param: 'reverse' });

--- a/test/suggesters-test/phrase-suggester.test.js
+++ b/test/suggesters-test/phrase-suggester.test.js
@@ -1,0 +1,54 @@
+import test from 'ava';
+import { PhraseSuggester, DirectGenerator } from '../../src';
+import { validatedCorrectly, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = () => new PhraseSuggester('my_suggester');
+
+const dirGenA = new DirectGenerator('title.trigram').suggestMode('always');
+const dirGenB = new DirectGenerator('title.reverse')
+    .suggestMode('always')
+    .preFilter('reverse')
+    .postFilter('reverse');
+
+const setsOption = makeSetsOptionMacro(
+    getInstance,
+    nameTypeExpectStrategy('my_suggester', 'phrase')
+);
+
+test(validatedCorrectly, getInstance, 'smoothing', [
+    'stupid_backoff',
+    'laplace',
+    'linear_interpolation'
+]);
+
+test(setsOption, 'gramSize', { param: 1 });
+test(setsOption, 'realWordErrorLikelihood', { param: 0.9 });
+test(setsOption, 'confidence', { param: 0 });
+test(setsOption, 'maxErrors', { param: 10 });
+test(setsOption, 'separator', { param: '|' });
+test(setsOption, 'highlight', {
+    param: ['<em>', '</em>'],
+    propValue: {
+        pre_tag: '<em>',
+        post_tag: '</em>'
+    }
+});
+test(setsOption, 'collate', {
+    param: {
+        query: {
+            inline: {
+                match: { '{{field_name}}': '{{suggestion}}' }
+            }
+        },
+        params: { field_name: 'title' },
+        prune: true
+    }
+});
+test(setsOption, 'smoothing', { param: 'stupid_backoff' });
+
+test.failing(setsOption, 'directGenerator', { param: dirGenA, propValue: [dirGenA] });
+test.failing(setsOption, 'directGenerator', {
+    param: [dirGenA, dirGenB],
+    spread: false,
+    propValue: [dirGenA]
+});

--- a/test/suggesters-test/term-suggester.test.js
+++ b/test/suggesters-test/term-suggester.test.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+import { TermSuggester } from '../../src';
+import { validatedCorrectly, nameTypeExpectStrategy, makeSetsOptionMacro } from '../_macros';
+
+const getInstance = () => new TermSuggester('my_suggester');
+
+const setsOption = makeSetsOptionMacro(getInstance, nameTypeExpectStrategy('my_suggester', 'term'));
+
+test(validatedCorrectly, getInstance, 'sort', ['score', 'frequency']);
+test(validatedCorrectly, getInstance, 'suggestMode', ['missing', 'popular', 'always']);
+test(validatedCorrectly, getInstance, 'stringDistance', [
+    'internal',
+    'damerau_levenshtein',
+    'levenstein',
+    'jarowinkler',
+    'ngram'
+]);
+
+test(setsOption, 'sort', { param: 'score' });
+test(setsOption, 'suggestMode', { param: 'always' });
+test(setsOption, 'maxEdits', { param: 3 });
+test(setsOption, 'prefixLength', { param: 3 });
+test(setsOption, 'minWordLength', { param: 5 });
+test(setsOption, 'maxInspections', { param: 4 });
+test(setsOption, 'minDocFreq', { param: 0.4 });
+test(setsOption, 'maxTermFreq', { param: 1 });
+test(setsOption, 'stringDistance', { param: 'damerau_levenshtein' });


### PR DESCRIPTION
Adds support for the following [Suggesters](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html):
- [`TermSuggester`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html).
- [`PhaseSuggester`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html).
- [`CompletionSuggester`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html). This also includes support for [Context Suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html)

Supporting/Base classes:
- `Suggester`
- `AnalyzedSuggesterBase`
- `DirectGenerator`

Tests and type definitions are also included.