### PR TITLE
Fix deprecation warning for HasChildQuery.type

### DIFF
--- a/src/queries/joining-queries/has-child-query.js
+++ b/src/queries/joining-queries/has-child-query.js
@@ -41,7 +41,7 @@ class HasChildQuery extends JoiningQueryBase {
     constructor(qry, type) {
         super('has_child', ES_REF_URL, qry);
 
-        if (!isNil(type)) this._queryOpts.child_type = type;
+        if (!isNil(type)) this._queryOpts.type = type;
     }
 
     /**
@@ -52,7 +52,8 @@ class HasChildQuery extends JoiningQueryBase {
      * @returns {HasChildQuery} returns `this` so that calls can be chained.
      */
     type(type) {
-        return this.childType(type);
+        this._queryOpts.type = type;
+        return this;
     }
 
     /**
@@ -62,8 +63,8 @@ class HasChildQuery extends JoiningQueryBase {
      * @returns {HasChildQuery} returns `this` so that calls can be chained.
      */
     childType(type) {
-        this._queryOpts.child_type = type;
-        return this;
+        console.warn('[HasChildQuery] Field `child_type` is deprecated. Use `type` instead.');
+        return this.type(type);
     }
 
     /**

--- a/test/queries-test/has-child-query.test.js
+++ b/test/queries-test/has-child-query.test.js
@@ -6,8 +6,8 @@ const setsOption = makeSetsOptionMacro(hasChildQuery, nameExpectStrategy('has_ch
 
 const qry = new TermQuery('user', 'kimchy');
 
-test(setsOption, 'type', { param: 'blog_tag', keyName: 'child_type' });
-test(setsOption, 'childType', { param: 'blog_tag' });
+test(setsOption, 'type', { param: 'blog_tag' });
+test(setsOption, 'childType', { param: 'blog_tag', keyName: 'type' });
 test(setsOption, 'minChildren', { param: 2 });
 test(setsOption, 'maxChildren', { param: 10 });
 
@@ -19,7 +19,7 @@ test('constructor sets argumetns', t => {
     const expected = {
         has_child: {
             query: { term: { user: 'kimchy' } },
-            child_type: 'my_type'
+            type: 'my_type'
         }
     };
     t.deepEqual(valueA, expected);


### PR DESCRIPTION
`child_type` field in `has_child` query is deprecated. Change `has_child>child_type` => `has_child>type`.

Closes #13