### PR TITLE
Add boolean values to type declarations for TermQuery

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1327,7 +1327,7 @@ declare namespace esb {
          *
          * @param {string|number} queryVal
          */
-        value(queryVal: string | number): this;
+        value(queryVal: string | number | boolean): this;
     }
 
     /**
@@ -1339,7 +1339,7 @@ declare namespace esb {
      * @extends ValueTermQueryBase
      */
     export class TermQuery extends ValueTermQueryBase {
-        constructor(field?: string, queryVal?: string | number);
+        constructor(field?: string, queryVal?: string | number | boolean);
     }
 
     /**
@@ -1351,7 +1351,7 @@ declare namespace esb {
      */
     export function termQuery(
         field?: string,
-        queryVal?: string | number
+        queryVal?: string | number | boolean
     ): TermQuery;
 
     /**
@@ -1362,7 +1362,7 @@ declare namespace esb {
      * @extends Query
      */
     export class TermsQuery extends Query {
-        constructor(field?: string, values?: string[] | string | number);
+        constructor(field?: string, values?: string[] | string | number | boolean);
 
         /**
          * Sets the field to search on.
@@ -1376,7 +1376,7 @@ declare namespace esb {
          *
          * @param {string|number} value
          */
-        value(value: string | number): this;
+        value(value: string | number | boolean): this;
 
         /**
          * Specifies the values to run query for.
@@ -1438,7 +1438,7 @@ declare namespace esb {
 
     export function termsQuery(
         field?: string,
-        values?: string[] | string | number
+        values?: string[] | string | number | boolean
     ): TermsQuery;
 
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1325,7 +1325,7 @@ declare namespace esb {
         /**
          * Sets the query string.
          *
-         * @param {string|number} queryVal
+         * @param {string|number|boolean} queryVal
          */
         value(queryVal: string | number | boolean): this;
     }
@@ -1335,7 +1335,7 @@ declare namespace esb {
      * in the inverted index.
      *
      * @param {string=} field
-     * @param {string|number=} queryVal
+     * @param {string|number|boolean=} queryVal
      * @extends ValueTermQueryBase
      */
     export class TermQuery extends ValueTermQueryBase {
@@ -1347,7 +1347,7 @@ declare namespace esb {
      * in the inverted index.
      *
      * @param {string=} field
-     * @param {string|number=} queryVal
+     * @param {string|number|boolean=} queryVal
      */
     export function termQuery(
         field?: string,
@@ -1358,7 +1358,7 @@ declare namespace esb {
      * Filters documents that have fields that match any of the provided terms (**not analyzed**).
      *
      * @param {string=} field
-     * @param {Array|string|number=} values
+     * @param {Array|string|number|boolean=} values
      * @extends Query
      */
     export class TermsQuery extends Query {
@@ -1374,7 +1374,7 @@ declare namespace esb {
         /**
          * Append given value to list of values to run Terms Query with.
          *
-         * @param {string|number} value
+         * @param {string|number|boolean} value
          */
         value(value: string | number | boolean): this;
 

--- a/src/queries/term-level-queries/term-query.js
+++ b/src/queries/term-level-queries/term-query.js
@@ -12,7 +12,7 @@ const ValueTermQueryBase = require('./value-term-query-base');
  * const termQry = esb.termQuery('user', 'Kimchy');
  *
  * @param {string=} field
- * @param {string|number=} queryVal
+ * @param {string|number|boolean=} queryVal
  *
  * @extends ValueTermQueryBase
  */

--- a/src/queries/term-level-queries/terms-query.js
+++ b/src/queries/term-level-queries/terms-query.js
@@ -24,7 +24,7 @@ const { Query } = require('../../core');
  *     .path('followers');
  *
  * @param {string=} field
- * @param {Array|string|number=} values
+ * @param {Array|string|number|boolean=} values
  *
  * @extends Query
  */
@@ -52,7 +52,7 @@ class TermsQuery extends Query {
      *
      * @private
      * @param {string} key
-     * @param {string|number} val
+     * @param {string|number|boolean} val
      */
     _setTermsLookupOpt(key, val) {
         this._isTermsLookup = true;
@@ -73,7 +73,7 @@ class TermsQuery extends Query {
     /**
      * Append given value to list of values to run Terms Query with.
      *
-     * @param {string|number} value
+     * @param {string|number|boolean} value
      * @returns {TermsQuery} returns `this` so that calls can be chained
      */
     value(value) {

--- a/src/queries/term-level-queries/value-term-query-base.js
+++ b/src/queries/term-level-queries/value-term-query-base.js
@@ -38,7 +38,7 @@ class ValueTermQueryBase extends Query {
     /**
      * Sets the query string.
      *
-     * @param {string|number} queryVal
+     * @param {string|number|boolean} queryVal
      * @returns {ValueTermQueryBase} returns `this` so that calls can be chained.
      */
     value(queryVal) {


### PR DESCRIPTION
Support [boolean](https://www.elastic.co/guide/en/elasticsearch/reference/current/boolean.html) values in TermQuery type declarations.