### PR TITLE
Remove node target to allow use in browser environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,6 @@
 {
   "presets": [
-    [
-      "env",
-      {
-        "targets": {
-          "node": 4
-        }
-      }
-    ]
+    "env"
   ],
   "plugins": [
     [


### PR DESCRIPTION
I think it would be useful to be able to use `elastic-builder` in a browser environment.

The current babel config only targets Node@4, which allows the use of backticks. This causes errors when using UglifyJS to minify code output.

My proposed change removes the node target and uses the default `babel-preset-env` setting.