### PR TITLE
Adds browsers: [>1%] to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,8 @@
       "env",
       {
         "targets": {
-          "node": 4
+          "node": 4,
+          "browsers": [">1%"]
         }
       }
     ]


### PR DESCRIPTION
In reference to #52 and #45, this adds a single line in the .babelrc to make this usable in browsers.

Closes #45, #52