### PR TITLE
feat: Implement new api for nested sorting for elasticsearch >= 6.1

### DIFF
--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -147,12 +147,12 @@ class Sort {
     }
 
     /**
-     * Note: This method is uncompatible with elasticsearch 6.0 and older.
-     * Use it only with elasticsearch 6.1 and later.
-     *
      * Defines on which nested object to sort and the filter that the inner objects inside
      * the nested path should match with in order for its field values to be taken into
      * account by sorting
+     *
+     * Note: This method is incompatible with elasticsearch 6.0 and older.
+     * Use it only with elasticsearch 6.1 and later.
      *
      * @example
      * const sort = esb.sort('offer.price', 'asc')

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -106,6 +106,9 @@ class Sort {
      * field inside this nested object. When sorting by nested field, this field
      * is mandatory.
      *
+     * Note: This method has been deprecated in elasticsearch 6.1. From 6.1 and
+     * later, use `nested` method instead.
+     *
      * @example
      * const sort = esb.sort('offer.price', 'asc')
      *     .nestedPath('offer')
@@ -124,12 +127,15 @@ class Sort {
      * for its field values to be taken into account by sorting. By default no
      * `nested_filter` is active.
      *
+     * Note: This method has been deprecated in elasticsearch 6.1. From 6.1 and
+     * later, use `nested` method instead.
+     *
      * @example
      * const sort = esb.sort('offer.price', 'asc')
      *     .nestedPath('offer')
      *     .nestedFilter(esb.termQuery('offer.color', 'blue'));
      *
-     * @param {Query} filterQuery
+     * @param {Query} filterQuery Filter query
      * @returns {Sort} returns `this` so that calls can be chained.
      * @throws {TypeError} If filter query is not an instance of `Query`
      */
@@ -137,6 +143,35 @@ class Sort {
         checkType(filterQuery, Query);
 
         this._opts.nested_filter = filterQuery;
+        return this;
+    }
+
+    /**
+     * Note: This method is uncompatible with elasticsearch 6.0 and older.
+     * Use it only with elasticsearch 6.1 and later.
+     *
+     * Defines on which nested object to sort and the filter that the inner objects inside
+     * the nested path should match with in order for its field values to be taken into
+     * account by sorting
+     *
+     * @example
+     * const sort = esb.sort('offer.price', 'asc')
+     *     .nested({
+     *          path: 'offer',
+     *          filter: esb.termQuery('offer.color', 'blue')
+     *      });
+     *
+     * @param {Object} nested Nested config that contains path and filter
+     * @param {string} nested.path Nested object to sort on
+     * @param {Query} nested.filter Filter query
+     * @returns {Sort} returns `this` so that calls can be chained.
+     * @throws {TypeError} If filter query is not an instance of `Query`
+     */
+    nested(nested) {
+        const { filter } = nested;
+        if (!isNil(filter)) checkType(filter, Query);
+
+        this._opts.nested = nested;
         return this;
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8230,6 +8230,17 @@ declare namespace esb {
         nestedFilter(filterQuery: Query): this;
 
         /**
+         * Defines on which nested object to sort and the filter that the inner objects inside
+         * the nested path should match with in order for its field values to be taken into
+         * account by sorting
+         *
+         * @param {Object} nested Nested config that contains path and filter
+         * @param {string} nested.path Nested object to sort on
+         * @param {Query} nested.filter Filter query
+         */
+        nested(nested: { path: string, filter: Query }): this;
+
+        /**
          * The missing parameter specifies how docs which are missing the field should
          * be treated: The missing value can be set to `_last`, `_first`, or a custom value
          * (that will be used for missing docs as the sort value). The default is `_last`.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8214,6 +8214,9 @@ declare namespace esb {
          * Defines on which nested object to sort. The actual sort field must be a direct
          * field inside this nested object. When sorting by nested field, this field
          * is mandatory.
+         * 
+         * Note: This method has been deprecated in elasticsearch 6.1. From 6.1 and
+         * later, use `nested` method instead.
          *
          * @param {string} path Nested object to sort on
          */
@@ -8224,6 +8227,9 @@ declare namespace esb {
          * for its field values to be taken into account by sorting. By default no
          * `nested_filter` is active.
          *
+         * Note: This method has been deprecated in elasticsearch 6.1. From 6.1 and
+         * later, use `nested` method instead.
+         * 
          * @param {Query} filterQuery
          * @throws {TypeError} If filter query is not an instance of `Query`
          */
@@ -8233,6 +8239,9 @@ declare namespace esb {
          * Defines on which nested object to sort and the filter that the inner objects inside
          * the nested path should match with in order for its field values to be taken into
          * account by sorting
+         * 
+         * Note: This method is incompatible with elasticsearch 6.0 and older.
+         * Use it only with elasticsearch 6.1 and later.
          *
          * @param {Object} nested Nested config that contains path and filter
          * @param {string} nested.path Nested object to sort on

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8214,7 +8214,7 @@ declare namespace esb {
          * Defines on which nested object to sort. The actual sort field must be a direct
          * field inside this nested object. When sorting by nested field, this field
          * is mandatory.
-         * 
+         *
          * Note: This method has been deprecated in elasticsearch 6.1. From 6.1 and
          * later, use `nested` method instead.
          *
@@ -8239,7 +8239,7 @@ declare namespace esb {
          * Defines on which nested object to sort and the filter that the inner objects inside
          * the nested path should match with in order for its field values to be taken into
          * account by sorting
-         * 
+         *
          * Note: This method is incompatible with elasticsearch 6.0 and older.
          * Use it only with elasticsearch 6.1 and later.
          *

--- a/test/core-test/sort.test.js
+++ b/test/core-test/sort.test.js
@@ -44,6 +44,19 @@ test(validatedCorrectly, getInstance, 'unit', [
 );
 test(setsOption, 'nestedPath', { param: 'offer' });
 test(setsOption, 'nestedFilter', { param: filterQry });
+test(setsOption, 'nested', {
+    param: {
+        filter: filterQry,
+        path: 'offer'
+    },
+    keyName: 'nested'
+});
+test(setsOption, 'nested', {
+    param: {
+        path: 'offer'
+    },
+    keyName: 'nested'
+});
 test(setsOption, 'missing', { param: '_last' });
 test(setsOption, 'unmappedType', { param: 'long' });
 test(setsOption, 'reverse', { param: true });


### PR DESCRIPTION
Adds compatibility of new `nested` api for elasticsearch >= 6.1
Removes deprecated `nested_path` and `nested_filter` options.
https://www.elastic.co/guide/en/elasticsearch/reference/6.3/search-request-sort.html#nested-sorting

**WARNING: This is breaking change and this will NOT work with elasticsearch < 6.1**

Usage example:
```
const sort = esb.sort('offer.price', 'asc')
    .nested({
        path: 'offer',
        filter: esb.termQuery('offer.color', 'blue')
    });
```

or with old style:

```
const sort = esb.sort('offer.price', 'asc')
    .nestedPath('offer')
    .nestedFilter(esb.termQuery('offer.color', 'blue'));
```

both examples produce the same output compatible with new elasticsearch api:
```
{
    'offer.price': {
        order: 'asc',
        nested: {
            path: 'offer',
            filter: {
                term: {
                    'offer.color': 'blue'
                }
            }
        }
    }
}
```