### PR TITLE
When using esb.sort().script(...)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8422,6 +8422,11 @@ declare namespace esb {
      * `asc`, `desc` to sort in ascending, descending order respectively.
      */
     export function sort(field: string, order?: string): Sort;
+    /**
+     * Allows creating and configuring sort on specified field
+     * but It is required .script()
+     */
+    export function sort(): Sort;
 
     /**
      * A `rescore` request can help to improve precision by reordering just


### PR DESCRIPTION
If `esb.sort()` is used without `field` parameter to use `esb.sort().script(...)`, We should omit `field` parameter.
This case is expression in the script section of [the document page](https://elastic-builder.js.org/docs/#sort).