### PR TITLE
feat: add support for `track_total_hits`

### DIFF
--- a/src/core/request-body-search.js
+++ b/src/core/request-body-search.js
@@ -317,7 +317,8 @@ class RequestBodySearch {
 
     /**
      * The `track_total_hits` parameter allows you to control how the total number of hits
-     * should be tracked.
+     * should be tracked. Passing `false` can increase performance in some situations.
+     * (Added in elasticsearch@7)
      *
      * Pass `true`, `false`, or the upper limit (default: `10000`) of hits you want tracked.
      *

--- a/src/core/request-body-search.js
+++ b/src/core/request-body-search.js
@@ -316,6 +316,20 @@ class RequestBodySearch {
     }
 
     /**
+     * The `track_total_hits` parameter allows you to control how the total number of hits
+     * should be tracked.
+     *
+     * Pass `true`, `false`, or the upper limit (default: `10000`) of hits you want tracked.
+     *
+     * @param {boolean|number} enableOrLimit
+     * @returns {RequestBodySearch} returns `this` so that calls can be chained
+     */
+    trackTotalHits(enableOrLimit) {
+        this._body.track_total_hits = enableOrLimit;
+        return this;
+    }
+
+    /**
      * Allows to control how the `_source` field is returned with every hit.
      * You can turn off `_source` retrieval by passing `false`.
      * It also accepts one(string) or more wildcard(array) patterns to control

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -135,6 +135,15 @@ declare namespace esb {
         trackScores(enable: boolean): this;
 
         /**
+         * The track_total_hits parameter allows you to control how the total number of hits should be tracked.
+         *
+         * Pass true, false, or the upper limit of hits you want tracked.
+         *
+         * @param {boolean|number} enable
+         */
+        trackTotalHits(enable: boolean|number): this;
+
+        /**
          * Allows to control how the `_source` field is returned with every hit.
          * You can turn off `_source` retrieval by passing `false`.
          * It also accepts one(string) or more wildcard(array) patterns to control

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -135,7 +135,9 @@ declare namespace esb {
         trackScores(enable: boolean): this;
 
         /**
-         * The track_total_hits parameter allows you to control how the total number of hits should be tracked.
+         * The `track_total_hits` parameter allows you to control how the total number of hits
+         * should be tracked. Passing `false` can increase performance in some situations.
+         * (Added in elasticsearch@7)
          *
          * Pass true, false, or the upper limit of hits you want tracked.
          *

--- a/test/core-test/request-body-search.test.js
+++ b/test/core-test/request-body-search.test.js
@@ -98,6 +98,7 @@ test(setsOption, 'sorts', {
     keyName: 'sort'
 });
 test(setsOption, 'trackScores', { param: true });
+test(setsOption, 'trackTotalHits', { param: true });
 test(setsOption, 'version', { param: true });
 test(setsOption, 'explain', { param: true });
 test(setsOption, 'highlight', {


### PR DESCRIPTION
Adds support for `track_total_hits` on request body search.

Fixes: #95 