### PR TITLE
Add CompositeAggregation#missingBucket

### DIFF
--- a/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
+++ b/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
@@ -106,6 +106,17 @@ class ValuesSourceBase {
     }
 
     /**
+     * Specifies to include documents without a value for a given source in the
+     * response,or not. Defaults to `false` (not include.
+     *
+     * @param {boolean} value
+     */
+    missingBucket(value) {
+        this._opts.missing_bucket = value;
+        return this;
+    }
+
+    /**
      * Override default `toJSON` to return DSL representation for the Composite
      * Aggregation values source.
      *

--- a/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
+++ b/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
@@ -97,6 +97,10 @@ class ValuesSourceBase {
      * Missing specifies the value to use when the source finds a missing value
      * in a document.
      *
+     * Note: The `missing` option of the composite aggregation is deprecated in
+     * [Elasticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation),
+     * `missing_bucket` should be used instead.
+     *
      * @param {string} value
      * @returns {ValuesSourceBase} returns `this` so that calls can be chained
      */
@@ -106,10 +110,14 @@ class ValuesSourceBase {
     }
 
     /**
-     * Specifies to include documents without a value for a given source in the
-     * response,or not. Defaults to `false` (not include.
+     * Specifies whether to include documents without a value for a given source
+     * in the response. Defaults to `false` (not included).
+     *
+     * Note: This method is incompatible with elasticsearch 5.6 and older.
+     * Use it only with elasticsearch 6.0 and later.
      *
      * @param {boolean} value
+     * @returns {ValuesSourceBase} returns `this` so that calls can be chained
      */
     missingBucket(value) {
         this._opts.missing_bucket = value;

--- a/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
+++ b/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
@@ -97,11 +97,11 @@ class ValuesSourceBase {
      * Missing specifies the value to use when the source finds a missing value
      * in a document.
      *
-     * Note: The `missing` option of the composite aggregation is deprecated in
-     * [Elasticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation),
-     * `missing_bucket` should be used instead.
+     * Note: This option was deprecated in
+     * [Elasticsearch v6](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation).
+     * From 6.4 and later, use `missing_bucket` instead.
      *
-     * @param {string} value
+     * @param {string|number} value
      * @returns {ValuesSourceBase} returns `this` so that calls can be chained
      */
     missing(value) {
@@ -113,8 +113,8 @@ class ValuesSourceBase {
      * Specifies whether to include documents without a value for a given source
      * in the response. Defaults to `false` (not included).
      *
-     * Note: This method is incompatible with elasticsearch 5.6 and older.
-     * Use it only with elasticsearch 6.0 and later.
+     * Note: This method is incompatible with elasticsearch 6.3 and older.
+     * Use it only with elasticsearch 6.4 and later.
      *
      * @param {boolean} value
      * @returns {ValuesSourceBase} returns `this` so that calls can be chained

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -143,7 +143,7 @@ declare namespace esb {
          *
          * @param {boolean|number} enable
          */
-        trackTotalHits(enable: boolean|number): this;
+        trackTotalHits(enable: boolean | number): this;
 
         /**
          * Allows to control how the `_source` field is returned with every hit.
@@ -4655,20 +4655,20 @@ declare namespace esb {
              * Missing specifies the value to use when the source finds a missing value
              * in a document.
              *
-             * Note: The `missing` option of the composite aggregation is deprecated in
-             * [Elasticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation),
-             * `missing_bucket` should be used instead.
-             * 
-             * @param {string} value
+             * Note: Thes option was deprecated in
+             * [Elasticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation).
+             * From 6.4 and later, use `missing_bucket` instead.
+             *
+             * @param {string|number} value
              */
-            missing(value: string): this;
+            missing(value: string | number): this;
 
             /**
              * Specifies to include documents without a value for a given source in the
              * response, or not. Defaults to `false` (not include).
              *
-             * Note: This method is incompatible with elasticsearch 5.6 and older.
-             * Use it only with elasticsearch 6.0 and later.
+             * Note: This method is incompatible with elasticsearch 6.3 and older.
+             * Use it only with elasticsearch 6.4 and later.
              *
              * @param {boolean} value
              */
@@ -8365,7 +8365,7 @@ declare namespace esb {
          * @param {string} nested.path Nested object to sort on
          * @param {Query} nested.filter Filter query
          */
-        nested(nested: { path: string, filter: Query }): this;
+        nested(nested: { path: string; filter: Query }): this;
 
         /**
          * The missing parameter specifies how docs which are missing the field should

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4655,9 +4655,21 @@ declare namespace esb {
              * Missing specifies the value to use when the source finds a missing value
              * in a document.
              *
+             * Note: The `missing` option of the composite aggregation is deprecated in
+             * [Elastticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation),
+             * `missing_bucket` should be used instead.
+             * 
              * @param {string} value
              */
             missing(value: string): this;
+
+            /**
+             * Specifies to include documents without a value for a given source in the
+             * response, or not. Defaults to `false` (not include).
+             * 
+             * @param {boolean} value
+             */
+            missingBucket(value: boolean): this;
 
             /**
              * Override default `toJSON` to return DSL representation for the Composite

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4656,7 +4656,7 @@ declare namespace esb {
              * in a document.
              *
              * Note: The `missing` option of the composite aggregation is deprecated in
-             * [Elastticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation),
+             * [Elasticsearch v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation),
              * `missing_bucket` should be used instead.
              * 
              * @param {string} value
@@ -4666,7 +4666,10 @@ declare namespace esb {
             /**
              * Specifies to include documents without a value for a given source in the
              * response, or not. Defaults to `false` (not include).
-             * 
+             *
+             * Note: This method is incompatible with elasticsearch 5.6 and older.
+             * Use it only with elasticsearch 6.0 and later.
+             *
              * @param {boolean} value
              */
             missingBucket(value: boolean): this;

--- a/test/aggregations-test/composite-agg-values-sources-test/terms-values-source.test.js
+++ b/test/aggregations-test/composite-agg-values-sources-test/terms-values-source.test.js
@@ -36,7 +36,7 @@ test('constructor sets arguments', t => {
 test(setsAggType, TermsValuesSource, 'terms');
 test(validatedCorrectly, getInstance, 'order', ['asc', 'desc']);
 test(setsOption, 'missing', { param: 42 });
-test(setsOption, 'missingBucket', { param: 42 });
+test(setsOption, 'missingBucket', { param: true });
 test(setsOption, 'field', { param: 'my_field' });
 test(setsOption, 'script', {
     param: new Script()

--- a/test/aggregations-test/composite-agg-values-sources-test/terms-values-source.test.js
+++ b/test/aggregations-test/composite-agg-values-sources-test/terms-values-source.test.js
@@ -36,6 +36,7 @@ test('constructor sets arguments', t => {
 test(setsAggType, TermsValuesSource, 'terms');
 test(validatedCorrectly, getInstance, 'order', ['asc', 'desc']);
 test(setsOption, 'missing', { param: 42 });
+test(setsOption, 'missingBucket', { param: 42 });
 test(setsOption, 'field', { param: 'my_field' });
 test(setsOption, 'script', {
     param: new Script()


### PR DESCRIPTION
Addresses [one of breking change in ES v6.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation).

This PR adds [CompositeAggregation#missingBucket](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html#_missing_bucket).
