### PR TITLE
FIX: termsQuery `values` argument type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1457,11 +1457,11 @@ declare namespace esb {
      * Filters documents that have fields that match any of the provided terms (**not analyzed**).
      *
      * @param {string=} field
-     * @param {Array|string|number|boolean=} values
+     * @param {Array<string|number|boolean>|string|number|boolean=} values
      */
     export function termsQuery(
         field?: string,
-        values?: string[] | string | number | boolean
+        values?: string[] | number[] | boolean[] | string | number | boolean
     ): TermsQuery;
 
     /**


### PR DESCRIPTION
Type for `values` argument in `TermsQuery` is `Array<string|number|boolean>`.

![image](https://user-images.githubusercontent.com/25078524/78886541-10c83d80-7a67-11ea-8ab4-58432c2e6de7.png)

Tested on online builder and all types work fine:
![image](https://user-images.githubusercontent.com/25078524/78886667-49681700-7a67-11ea-9d83-0f2d83a86829.png)

