### PR TITLE
Added calendar_interval and fixed_interval to date-histogram aggregation

### DIFF
--- a/src/aggregations/bucket-aggregations/date-histogram-aggregation.js
+++ b/src/aggregations/bucket-aggregations/date-histogram-aggregation.js
@@ -51,6 +51,50 @@ class DateHistogramAggregation extends HistogramAggregationBase {
         this._aggsDef.time_zone = tz;
         return this;
     }
+
+    /**
+     * Calendar-aware intervals are configured with the calendarInterval parameter.
+     * The combined interval field for date histograms is deprecated from ES 7.2.
+     *
+     * @example
+     * const agg = esb.dateHistogramAggregation('by_month', 'date').calendarInterval(
+     *     'month'
+     * );
+     *
+     * @param {string} interval Interval to generate histogram over.
+     * You can specify calendar intervals using the unit name, such as month, or as
+     * a single unit quantity, such as 1M. For example, day and 1d are equivalent.
+     * Multiple quantities, such as 2d, are not supported.
+     * @returns {DateHistogramAggregation} returns `this` so that calls can be chained
+     */
+    calendarInterval(interval) {
+        this._aggsDef.calendar_interval = interval;
+        return this;
+    }
+
+    /**
+     * Fixed intervals are configured with the fixedInterval parameter.
+     * The combined interval field for date histograms is deprecated from ES 7.2.
+     *
+     * @param {string} interval Interval to generate histogram over.
+     * Intervals are a fixed number of SI units and never deviate, regardless
+     * of where they fall on the calendar. However, it means fixed intervals
+     * cannot express other units such as months, since the duration of a
+     * month is not a fixed quantity.
+     *
+     * @example
+     * const agg = esb.dateHistogramAggregation('by_minute', 'date').calendarInterval(
+     *     '60s'
+     * );
+     *
+     * The accepted units for fixed intervals are:
+     * millseconds (ms), seconds (s), minutes (m), hours (h) and days (d).
+     * @returns {DateHistogramAggregation} returns `this` so that calls can be chained
+     */
+    fixedInterval(interval) {
+        this._aggsDef.fixed_interval = interval;
+        return this;
+    }
 }
 
 module.exports = DateHistogramAggregation;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5019,6 +5019,32 @@ declare namespace esb {
          * an identifier used in the TZ database like America/Los_Angeles.
          */
         timeZone(tz: string): this;
+
+        /**
+         * Calendar-aware intervals are configured with the calendarInterval parameter.
+         * The combined interval field for date histograms is deprecated from ES 7.2.
+         *
+         * @param {string} interval Interval to generate histogram over.
+         * You can specify calendar intervals using the unit name, such as month, or as
+         * a single unit quantity, such as 1M. For example, day and 1d are equivalent.
+         * Multiple quantities, such as 2d, are not supported.
+         */
+        calendarInterval(interval: string): this;
+
+        /**
+         * Fixed intervals are configured with the fixedInterval parameter.
+         * The combined interval field for date histograms is deprecated from ES 7.2.
+         *
+         * @param {string} interval Interval to generate histogram over.
+         * Intervals are a fixed number of SI units and never deviate, regardless
+         * of where they fall on the calendar. However, it means fixed intervals
+         * cannot express other units such as months, since the duration of a
+         * month is not a fixed quantity.
+         *
+         * The accepted units for fixed intervals are:
+         * millseconds (ms), seconds (s), minutes (m), hours (h) and days (d).
+         */
+        fixedInterval(interval: string): this;
     }
 
     /**

--- a/test/aggregations-test/date-histogram-agg.test.js
+++ b/test/aggregations-test/date-histogram-agg.test.js
@@ -36,3 +36,33 @@ test('time_zone is set', t => {
     };
     t.deepEqual(value, expected);
 });
+
+test('calendar_interval_is_set', t => {
+    const value = new DateHistogramAggregation('by_day', 'date')
+        .calendarInterval('month')
+        .toJSON();
+    const expected = {
+        by_day: {
+            date_histogram: {
+                field: 'date',
+                calendar_interval: 'month'
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+});
+
+test('fixed_interval_is_set', t => {
+    const value = new DateHistogramAggregation('by_day', 'date')
+        .fixedInterval('90s')
+        .toJSON();
+    const expected = {
+        by_day: {
+            date_histogram: {
+                field: 'date',
+                fixed_interval: '90s'
+            }
+        }
+    };
+    t.deepEqual(value, expected);
+});


### PR DESCRIPTION
Supported from ES 7.2.

Not sure on how to go about 7.x-isms here. Basically, for date histograms the old `interval` is no more (see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html), but elastic-builder supports interval as an explicit function on the aggregation and even as a third optional constructor parameter.

So for 7.x-compatible queries, its necessary to contruct the aggregation with only `name` and `field`, and add the `fixed_interval` via function (see tests).

Also wondering if we should make sure only one of `interval`, `fixed_interval` and `calendar_interval` is being set, since these are mutually exclusive. I am leaning towards "let users shoot themselves in their feet there", as opposed to some magic happening behind the scenes repairing fundamentally broken query builds.