### PR TITLE
Add CompletionSuggester.skipDuplicates

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7944,6 +7944,15 @@ declare namespace esb {
         prefix(prefix: string): this;
 
         /**
+         * Sets whether duplicate suggestions should be filtered out (defaults to false).
+         *
+         * NOTE: This option was added in elasticsearch v6.1.
+         *
+         * @param {boolean} skip Enable/disable skipping duplicates
+         */
+        skipDuplicates(skip?: boolean): this;
+
+        /**
          * Sets the `fuzzy` parameter. Can be customised with specific fuzzy parameters.
          *
          * @param {boolean|Object=} fuzzy Enable/disable `fuzzy` using boolean or

--- a/src/suggesters/completion-suggester.js
+++ b/src/suggesters/completion-suggester.js
@@ -58,6 +58,19 @@ class CompletionSuggester extends Suggester {
     }
 
     /**
+     * Sets whether duplicate suggestions should be filtered out (defaults to false).
+     *
+     * NOTE: This option was added in elasticsearch v6.1.
+     *
+     * @param {boolean} skip Enable/disable skipping duplicates
+     * @returns {CompletionSuggester} returns `this` so that calls can be chained.
+     */
+    skipDuplicates(skip = true) {
+        this._suggestOpts.skip_duplicates = skip;
+        return this;
+    }
+
+    /**
      * Check that the object property `this._suggestOpts.fuzzy` is an object.
      * Set empty object if required.
      *

--- a/test/suggesters-test/completion-suggester.test.js
+++ b/test/suggesters-test/completion-suggester.test.js
@@ -22,6 +22,7 @@ test('prefix is set', t => {
     t.deepEqual(value, expected);
 });
 
+test(setsOption, 'skipDuplicates', { propValue: true });
 test(setsOption, 'fuzzy', { param: true });
 test(setsOption, 'fuzzy', { propValue: true });
 test(setsOption, 'fuzziness', {


### PR DESCRIPTION
This PR adds support for the [skip_duplicates option of completion suggesters](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#skip_duplicates) added in ES 6.1.