### PR TITLE
feat: Add type option to queryStringQuery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ This is the last step! Make sure your PR is aimed to merge with the `master`
 branch.
 
 You should also write a good PR message with information on why this feature or
-fix is necesary or a good idea. For features, be sure to include information on
+fix is necessary or a good idea. For features, be sure to include information on
 how to use the feature; and for bugs, information on how to reproduce the bug is
 helpful!
 

--- a/src/core/consts.js
+++ b/src/core/consts.js
@@ -108,6 +108,15 @@ exports.GEO_RELATION_SET = new Set([
     'INTERSECTS'
 ]);
 
+exports.QUERY_STRING_TYPE = new Set([
+    'best_fields',
+    'most_fields',
+    'cross_fields',
+    'phrase',
+    'phrase_prefix',
+    'bool_prefix'
+]);
+
 exports.SUGGEST_MODE_SET = new Set(['missing', 'popular', 'always']);
 
 exports.STRING_DISTANCE_SET = new Set([

--- a/src/queries/full-text-queries/query-string-query.js
+++ b/src/queries/full-text-queries/query-string-query.js
@@ -2,9 +2,15 @@
 
 const QueryStringQueryBase = require('./query-string-query-base');
 const { validateRewiteMethod } = require('../helper');
-
+const isNil = require('lodash.isnil');
+const {
+    util: { invalidParam },
+    consts: { QUERY_STRING_TYPE }
+} = require('../../core');
 const ES_REF_URL =
     'https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html';
+
+const invalidTypeParam = invalidParam(ES_REF_URL, 'type', QUERY_STRING_TYPE);
 
 /**
  * A query that uses a query parser in order to parse its content.
@@ -301,6 +307,42 @@ class QueryStringQuery extends QueryStringQueryBase {
      */
     escape(enable) {
         this._queryOpts.escape = enable;
+        return this;
+    }
+
+    /**
+     * Sets the type of query string query. Valid values are:
+     * - `best_fields` - (default) Finds documents which match any field,
+     * but uses the `_score` from the best field.
+     *
+     * - `most_fields` - Finds documents which match any field and combines
+     * the `_score` from each field.
+     *
+     * - `cross_fields` - Treats fields with the same `analyzer` as though
+     * they were one big field. Looks for each word in *any* field
+     *
+     * - `phrase` - Runs a `match_phrase` query on each field and combines
+     * the `_score` from each field.
+     *
+     * - `phrase_prefix` - Runs a `match_phrase_prefix` query on each field
+     * and combines the `_score` from each field.
+     *
+     * - `bool_prefix` - Creates a match_bool_prefix query on each field and
+     * combines the _score from each field.
+     *
+     *
+     * @param {string} type Can be one of `best_fields`, `most_fields`,
+     * `cross_fields`, `phrase`, `phrase_prefix` and `bool_prefix`. Default is
+     * `best_fields`.
+     * @returns {QueryStringQuery} returns `this` so that calls can be chained.
+     */
+    type(type) {
+        if (isNil(type)) invalidTypeParam(type);
+
+        const typeLower = type.toLowerCase();
+        if (!QUERY_STRING_TYPE.has(typeLower)) invalidTypeParam(type);
+
+        this._queryOpts.type = typeLower;
         return this;
     }
 }

--- a/test/queries-test/query-string-query.test.js
+++ b/test/queries-test/query-string-query.test.js
@@ -21,7 +21,15 @@ const validRewrites = [
     'top_terms_boost_23',
     'top_terms_15'
 ];
-
+const validType = [
+    'best_fields',
+    'most_fields',
+    'cross_fields',
+    'phrase',
+    'phrase_prefix',
+    'bool_prefix'
+];
+test(validatedCorrectly, getInstance, 'type', validType, false);
 test(validatedCorrectly, getInstance, 'rewrite', validRewrites, false);
 test(validatedCorrectly, getInstance, 'fuzzyRewrite', validRewrites, false);
 test(setsOption, 'defaultField', { param: 'my_field' });
@@ -41,3 +49,4 @@ test(setsOption, 'useDisMax', { param: true });
 test(setsOption, 'tieBreaker', { param: 0.3 });
 test(setsOption, 'quoteAnalyzer', { param: 'my_analyzer' });
 test(setsOption, 'escape', { param: true });
+test(setsOption, 'type', { param: 'best_fields' });


### PR DESCRIPTION
Add the ability to pass in a type to the query string query. It can be used just all the other options available on the queryStringQuery `.type('most_fields')`

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-multi-field-parms