### PR TITLE
fix: use newly added util.inspect, for queries, do not import

### DIFF
--- a/src/queries/helper.js
+++ b/src/queries/helper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { inspect } = require('util');
+const { inspect } = require('../core/inspect');
 
 const {
     util: { firstDigitPos },


### PR DESCRIPTION
use  the local copy of util.inspect, recently added to the core directory consistently in queries/helper.js, instead of import This correction consistently uses the same inspect as the rest of the code base.

This patch  allows for using in angular 14+ and the migration to webpack > 4 without the need for adding polyfills
I saw your correction to core, and am guessing this line was an oversight?