### PR TITLE
fix: parameters type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5119,7 +5119,7 @@ declare namespace esb {
          * @param {number} buckets Bucket count to generate histogram over.
          * @returns {VariableWidthHistogramAggregation} returns `this` so that calls can be chained
          */
-        buckets(buckets): this;
+        buckets(buckets: number): this;
     }
 
     /**


### PR DESCRIPTION
When type checking in strict mode this line will trigger an error.

```
node_modules/elastic-builder/src/index.d.ts(5122,17): error TS7006: Parameter 'buckets' implicitly has an 'any' type.
```