### PR TITLE
feat: Add support for date histogram hard_bounds

### DIFF
--- a/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
@@ -146,7 +146,6 @@ class HistogramAggregationBase extends BucketAggregationBase {
      * Set's the range/bounds for the histogram aggregation.
      * Useful when you want to include buckets that might be
      * outside the bounds of indexed documents.
-     * NOTE: Only available in Elasticsearch v7.10.0+
      *
      * @example
      * const agg = esb.histogramAggregation('prices', 'price', 50).extendedBounds(0, 500);
@@ -172,6 +171,7 @@ class HistogramAggregationBase extends BucketAggregationBase {
      * Set's the range/bounds for the histogram aggregation.
      * Useful when you want to limit the range of buckets in the histogram.
      * It is particularly useful in the case of open data ranges that can result in a very large number of buckets.
+     * NOTE: Only available in Elasticsearch v7.10.0+
      *
      * @example
      * const agg = esb.histogramAggregation('prices', 'price', 50).hardBounds(0, 500);

--- a/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
@@ -146,6 +146,7 @@ class HistogramAggregationBase extends BucketAggregationBase {
      * Set's the range/bounds for the histogram aggregation.
      * Useful when you want to include buckets that might be
      * outside the bounds of indexed documents.
+     * NOTE: Only available in Elasticsearch v7.10.0+
      *
      * @example
      * const agg = esb.histogramAggregation('prices', 'price', 50).extendedBounds(0, 500);

--- a/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
@@ -168,6 +168,31 @@ class HistogramAggregationBase extends BucketAggregationBase {
     }
 
     /**
+     * Set's the range/bounds for the histogram aggregation.
+     * Useful when you want to limit the range of buckets in the histogram.
+     * It is particularly useful in the case of open data ranges that can result in a very large number of buckets.
+     *
+     * @example
+     * const agg = esb.histogramAggregation('prices', 'price', 50).hardBounds(0, 500);
+     *
+     * @param {number|string} min Start bound / minimum bound value
+     * For histogram aggregation, Integer value can be used.
+     * For Date histogram, date expression can be used.
+     * Available expressions for interval:
+     * year, quarter, month, week, day, hour, minute, second
+     * @param {number|string} max End bound / maximum bound value
+     * For histogram aggregation, Integer value can be used.
+     * For Date histogram, date expression can be used.
+     * Available expressions for interval:
+     * year, quarter, month, week, day, hour, minute, second
+     * @returns {HistogramAggregationBase} returns `this` so that calls can be chained
+     */
+    hardBounds(min, max) {
+        this._aggsDef.hard_bounds = { min, max };
+        return this;
+    }
+
+    /**
      * Sets the missing parameter which defines how documents
      * that are missing a value should be treated.
      *

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5015,6 +5015,7 @@ declare namespace esb {
          * Set's the range/bounds for the histogram aggregation.
          * Useful when you want to limit the range of buckets in the histogram.
          * It is particularly useful in the case of open data ranges that can result in a very large number of buckets.
+         * NOTE: Only available in Elasticsearch v7.10.0+
          *
          * @example
          * const agg = esb.histogramAggregation('prices', 'price', 50).hardBounds(0, 500);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5012,6 +5012,28 @@ declare namespace esb {
         extendedBounds(min: number | string, max: number | string): this;
 
         /**
+         * Set's the range/bounds for the histogram aggregation.
+         * Useful when you want to limit the range of buckets in the histogram.
+         * It is particularly useful in the case of open data ranges that can result in a very large number of buckets.
+         *
+         * @example
+         * const agg = esb.histogramAggregation('prices', 'price', 50).hardBounds(0, 500);
+         *
+         * @param {number|string} min Start bound / minimum bound value
+         * For histogram aggregation, Integer value can be used.
+         * For Date histogram, date expression can be used.
+         * Available expressions for interval:
+         * year, quarter, month, week, day, hour, minute, second
+         * @param {number|string} max End bound / maximum bound value
+         * For histogram aggregation, Integer value can be used.
+         * For Date histogram, date expression can be used.
+         * Available expressions for interval:
+         * year, quarter, month, week, day, hour, minute, second
+         * @returns {HistogramAggregationBase} returns `this` so that calls can be chained
+         */
+        hardBounds(min: number | string, max: number | string): this;
+
+        /**
          * Sets the missing parameter which defines how documents
          * that are missing a value should be treated.
          *

--- a/test/aggregations-test/histogram-agg-base.test.js
+++ b/test/aggregations-test/histogram-agg-base.test.js
@@ -20,6 +20,10 @@ test(setsOption, 'extendedBounds', {
     param: [0, 500],
     propValue: { min: 0, max: 500 }
 });
+test(setsOption, 'hardBounds', {
+    param: [0, 500],
+    propValue: { min: 0, max: 500 }
+});
 test(setsOption, 'order', {
     param: 'my_field',
     propValue: { my_field: 'desc' }


### PR DESCRIPTION
Fix https://github.com/sudo-suhas/elastic-builder/issues/169
Implements hard_bounds for date histograms, the counterpart of the already existing extended_bounds. 

https://github.com/elastic/elasticsearch/issues/59774 implemented in 7.10