### PR TITLE
Add custom query class that can be used to extend with query types not supported in this module

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -349,6 +349,21 @@ declare namespace esb {
     }
 
     /**
+     * Extensible custom query to support types of queries not implemented in this module
+     *
+     * @extends Query
+     */
+    export class CustomQuery extends Query {
+        constructor(queryType: string, field?: string)
+
+        field(field: string): this;
+
+        toJSON(): object;
+    }
+
+    export function customQuery(): CustomQuery;
+    
+    /**
      * The most simple query, which matches all documents, giving them all a `_score` of `1.0`.
      *
      * @extends Query

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const {
 const {
     MatchAllQuery,
     MatchNoneQuery,
+    CustomQuery,
     fullTextQueries: {
         MatchQuery,
         MatchPhraseQuery,
@@ -167,6 +168,9 @@ exports.requestBodySearch = constructorWrapper(RequestBodySearch);
 /* ============ ============ ============ */
 /* ============== Queries =============== */
 /* ============ ============ ============ */
+exports.CustomQuery = CustomQuery;
+exports.customQuery = constructorWrapper(CustomQuery);
+
 exports.MatchAllQuery = MatchAllQuery;
 exports.matchAllQuery = constructorWrapper(MatchAllQuery);
 

--- a/src/queries/custom-query.js
+++ b/src/queries/custom-query.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+const { Query } = require('../core');
+
+class CustomQuery extends Query {
+    // eslint-disable-next-line require-jsdoc
+    constructor(queryType, field) {
+        super(queryType, field);
+
+        if (!isNil(field)) this._field = field;
+    }
+
+    field(field) {
+        this._field = field;
+        return this;
+    }
+
+    toJSON() {
+        const repr = {
+            [this.queryType]: {
+                [this._field]: this._queryOpts
+            }
+        };
+        return repr;
+    }
+}
+
+module.exports = CustomQuery;

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+exports.CustomQuery = require('./custom-query');
+
 exports.MatchAllQuery = require('./match-all-query');
 exports.MatchNoneQuery = require('./match-none-query');
 

--- a/test/queries-test/custom-query.test.js
+++ b/test/queries-test/custom-query.test.js
@@ -1,0 +1,9 @@
+import test from 'ava';
+import { CustomQuery } from '../../src';
+
+test('can be instantiated', t => {
+    const value = new CustomQuery('neural', 'field1').toJSON();
+
+    const expected = { neural: { field1: {} } };
+    t.deepEqual(value, expected);
+});


### PR DESCRIPTION
We are using later versions of ES, and there are new types of queries introduced not supported in this module. We need to be able to extend from a public class to create new query types. An example is the [Text Expansion Query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-text-expansion-query.html). 

In order to create new queries in our codebase using this query builder, we can create custom extensions. However, a public custom query class is missing, making this not possible. This is the reason why I am proposing to add it to have this flexibility. 

@sudo-suhas could you please check out this PR? 