### PR TITLE
Make `Query` public to allow custom query extensions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -317,7 +317,7 @@ declare namespace esb {
      *
      * @param {string} queryType
      */
-    class Query {
+    export class Query {
         constructor(queryType: string);
 
         /**

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const {
     Rescore,
     InnerHits,
     SearchTemplate,
+    Query,
     util: { constructorWrapper }
 } = require('./core');
 
@@ -167,6 +168,9 @@ exports.requestBodySearch = constructorWrapper(RequestBodySearch);
 /* ============ ============ ============ */
 /* ============== Queries =============== */
 /* ============ ============ ============ */
+exports.Query = Query;
+exports.query = constructorWrapper(Query);
+
 exports.MatchAllQuery = MatchAllQuery;
 exports.matchAllQuery = constructorWrapper(MatchAllQuery);
 


### PR DESCRIPTION
Export `Query` in index.js to allow extensions for special query types that may not be part of the official ES DSL.

We are using this query builder for OpenSearch, where a [new plugin adds the `neural` query](https://opensearch.org/docs/latest/search-plugins/neural-search/). I foresee that the type of queries used in OpenSearch and Elasticsearch will diverge in the future, so it would be nice that we can still use this module as a base to create queries for both. 

There are also other query types used in ES in later versions, which are not commonly used, but can be useful to add yourself like the 
- [Text Expansion query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-text-expansion-query.html)
- [Shape](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-shape-query.html) query

By making the `Query` class public, it is easier to add extensions in TS. 

Note that I have shared a [workaround here](https://github.com/sudo-suhas/elastic-builder/pull/183) to still allow extensions, but with this PR, we can skip that. 

@sudo-suhas , can you please check this PR?
