### PR TITLE
fix: export aggregation bases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ const {
         StatsAggregation,
         SumAggregation,
         TopHitsAggregation,
-        ValueCountAggregation
+        ValueCountAggregation,
+        MetricsAggregationBase
     },
     bucketAggregations: {
         AdjacencyMatrixAggregation,
@@ -131,7 +132,12 @@ const {
         SamplerAggregation,
         SignificantTermsAggregation,
         SignificantTextAggregation,
-        TermsAggregation
+        TermsAggregation,
+        RangeAggregationBase,
+        TermsAggregationBase,
+        BucketAggregationBase,
+        HistogramAggregationBase,
+        SignificantAggregationBase
     },
     pipelineAggregations: {
         AvgBucketAggregation,
@@ -148,7 +154,8 @@ const {
         BucketScriptAggregation,
         BucketSelectorAggregation,
         SerialDifferencingAggregation,
-        BucketSortAggregation
+        BucketSortAggregation,
+        PipelineAggregationBase
     },
     matrixAggregations: { MatrixStatsAggregation }
 } = require('./aggregations');
@@ -378,6 +385,8 @@ exports.topHitsAggregation = constructorWrapper(TopHitsAggregation);
 exports.ValueCountAggregation = ValueCountAggregation;
 exports.valueCountAggregation = constructorWrapper(ValueCountAggregation);
 
+exports.MetricsAggregationBase = MetricsAggregationBase;
+
 /* ============ ============ ============ */
 /* ========= Bucket Aggregations ======== */
 /* ============ ============ ============ */
@@ -474,6 +483,16 @@ exports.significantTextAggregation = constructorWrapper(
 exports.TermsAggregation = TermsAggregation;
 exports.termsAggregation = constructorWrapper(TermsAggregation);
 
+exports.RangeAggregationBase = RangeAggregationBase;
+
+exports.TermsAggregationBase = TermsAggregationBase;
+
+exports.BucketAggregationBase = BucketAggregationBase;
+
+exports.HistogramAggregationBase = HistogramAggregationBase;
+
+exports.SignificantAggregationBase = SignificantAggregationBase;
+
 /* ============ ============ ============ */
 /* ======== Pipeline Aggregations ======= */
 /* ============ ============ ============ */
@@ -531,6 +550,8 @@ exports.SerialDifferencingAggregation = SerialDifferencingAggregation;
 exports.serialDifferencingAggregation = constructorWrapper(
     SerialDifferencingAggregation
 );
+
+exports.PipelineAggregationBase = PipelineAggregationBase;
 
 /* ============ ============ ============ */
 /* ========= Matrix Aggregations ======== */


### PR DESCRIPTION
Hi, 

I noticed the type definitions of the aggregation bases are exported in [index.d.ts](https://github.com/sudo-suhas/elastic-builder/blob/master/src/index.d.ts) but the actual classes are not exported in [index.js](https://github.com/sudo-suhas/elastic-builder/blob/master/src/index.js). I exported them, so we can add a custom implementation by extending the bases.