### PR TITLE
Feat/Add support for runtime_mappings [Issue: #152]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,13 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "eslint.enable": true,
-  "eslint.autoFixOnSave": true,
   "files.eol": "\n",
   "vsicons.presets.angular": false,
   "editor.detectIndentation": true,
   "[json]": {
     "editor.tabSize": 2
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "author": "Suhas Karanth <sudo.suhas@gmail.com>",
   "contributors": [
     "austin ce <austin.cawley@gmail.com>",
+    "Julien Maitrehenry <julien.maitrehenry@me.com>",
     "ochan12 <mateochando@gmail.com>",
     "kennylindahl <haxxblaster@gmail.com>",
     "foxstarius <aj.franzon@gmail.com>",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -31,3 +31,5 @@ exports.SearchTemplate = require('./search-template');
 exports.consts = require('./consts');
 
 exports.util = require('./util');
+
+exports.RuntimeField = require('./runtime-field');

--- a/src/core/request-body-search.js
+++ b/src/core/request-body-search.js
@@ -407,6 +407,74 @@ class RequestBodySearch {
     }
 
     /**
+     * Computes a document property dynamically based on the supplied `script`.
+     *
+     * @example
+     * const reqBody = esb.requestBodySearch()
+     *     .query(esb.matchAllQuery())
+     *     .runtimeField(
+     *       'sessionId-name',
+     *       esb.runtimeField(
+     *         'keyword',
+     *         `emit(doc['session_id'].value + '::' + doc['name'].value)`
+     *       )
+     *     )
+     *
+     * @example
+     * // runtime fields can also be used in query aggregation
+     * const reqBody = esb.requestBodySearch()
+     *     .query(esb.matchAllQuery())
+     *     .runtimeField(
+     *       'sessionId-eventName',
+     *       esb.runtimeField(
+     *         'keyword',
+     *         `emit(doc['session_id'].value + '::' + doc['eventName'].value)`,
+     *       )
+     *     )
+     *     .agg(esb.cardinalityAggregation('uniqueCount', `sessionId-eventName`)),;
+     *
+     * @param {string} runtimeFieldName
+     * @param {RuntimeField} instance of `RuntimeField`
+     * @returns {RequestBodySearch} returns `this` so that calls can be chained
+     */
+    runtimeMapping(runtimeMappingName, runtimeField) {
+        setDefault(this._body, 'runtime_mappings', {});
+        this._body.runtime_mappings[runtimeMappingName] = runtimeField;
+        return this;
+    }
+
+    /**
+     * Computes one or more document properties dynamically based on supplied `RuntimeField`s.
+     *
+     * @example
+     * const fieldA = esb.runtimeField(
+     *       'keyword',
+     *       `emit(doc['session_id'].value + '::' + doc['name'].value)`,
+     *       'sessionId-name'
+     * );
+     * const reqBody = esb.requestBodySearch()
+     *     .query(esb.matchAllQuery())
+     *     .runtimeFields({
+     *       'sessionId-name': fieldA,
+     *     })
+     *
+     * @param {Object} runtimeFields Object with `runtimeFieldName` as key and `RuntimeField` instance as the value.
+     * @returns {RequestBodySearch} returns `this` so that calls can be chained
+     */
+    runtimeMappings(runtimeMappings) {
+        checkType(runtimeMappings, Object);
+
+        Object.keys(runtimeMappings).forEach(runtimeMappingName =>
+            this.runtimeMapping(
+                runtimeMappingName,
+                runtimeMappings[runtimeMappingName]
+            )
+        );
+
+        return this;
+    }
+
+    /**
      * Computes a document property dynamically based on the supplied `Script`.
      *
      * @example

--- a/src/core/runtime-field.js
+++ b/src/core/runtime-field.js
@@ -13,10 +13,24 @@ const validType = [
     'lookup'
 ];
 
+/**
+ * Class supporting the Elasticsearch runtime field.
+ *
+ * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html)
+ *
+ * Added in Elasticsearch v7.11.0
+ * [Release note](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.0.html)
+ *
+ * @param {string=} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
+ * @param {string=} script Source of the script.
+ *
+ * @example
+ * const field = esb.runtimeField('keyword', `emit(doc['sessionId'].value + '::' + doc['name'].value)`);
+ */
 class RuntimeField {
-    constructor(type, script, name) {
+    // eslint-disable-next-line require-jsdoc
+    constructor(type, script) {
         this._body = {};
-        this._name = name;
         this._isTypeSet = false;
         this._isScriptSet = false;
 
@@ -29,10 +43,11 @@ class RuntimeField {
         }
     }
 
-    name(name) {
-        this._name = name;
-    }
-
+    /**
+     * Sets the source of the script.
+     * @param {string} script
+     * @returns {void}
+     */
     script(script) {
         this._body.script = {
             source: script
@@ -40,6 +55,11 @@ class RuntimeField {
         this._isScriptSet = true;
     }
 
+    /**
+     * Sets the type of the runtime field.
+     * @param {string} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
+     * @returns {void}
+     */
     type(type) {
         const typeLower = type.toLowerCase();
         if (!validType.includes(typeLower)) {

--- a/src/core/runtime-field.js
+++ b/src/core/runtime-field.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const isNil = require('lodash.isnil');
+const validType = [
+    'boolean',
+    'composite',
+    'date',
+    'double',
+    'geo_point',
+    'ip',
+    'keyword',
+    'long',
+    'lookup'
+];
+
+class RuntimeField {
+    constructor(type, script, name) {
+        this._body = {};
+        this._name = name;
+        this._isTypeSet = false;
+        this._isScriptSet = false;
+
+        if (!isNil(type)) {
+            this.type(type);
+        }
+
+        if (!isNil(script)) {
+            this.script(script);
+        }
+    }
+
+    name(name) {
+        this._name = name;
+    }
+
+    script(script) {
+        this._body.script = {
+            source: script
+        };
+        this._isScriptSet = true;
+    }
+
+    type(type) {
+        const typeLower = type.toLowerCase();
+        if (!validType.includes(typeLower)) {
+            throw new Error(`\`type\` must be one of ${validType.join(', ')}`);
+        }
+        this._body.type = typeLower;
+        this._isTypeSet = true;
+    }
+
+    /**
+     * Override default `toJSON` to return DSL representation for the `script`.
+     *
+     * @override
+     * @returns {Object} returns an Object which maps to the elasticsearch query DSL
+     */
+    toJSON() {
+        if (!this._isTypeSet) {
+            throw new Error('`type` should be set');
+        }
+
+        if (!this._isScriptSet) {
+            throw new Error('`script` should be set');
+        }
+
+        return this._body;
+    }
+}
+
+module.exports = RuntimeField;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -167,6 +167,9 @@ declare namespace esb {
          */
         storedFields(fields: object | string): this;
 
+        runtimeMapping(runtimeMappingName: string, script: string | RuntimeField): this;
+        runtimeMappings(runtimeMappings: object): this;
+
         /**
          * Computes a document property dynamically based on the supplied `Script`.
          *
@@ -8760,6 +8763,20 @@ declare namespace esb {
      * @param {string|Array=} fields An optional field or array of fields to highlight.
      */
     export function highlight(fields?: string | string[]): Highlight;
+
+    export class RuntimeField {
+        constructor(type?: string, script?: string, name?: string);
+        name(name: string);
+        type(type: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup');
+        script(script: string);
+        /**
+         * Override default `toJSON` to return DSL representation for the `script`.
+         *
+         * @override
+         */
+        toJSON(): object;
+    }
+    export function runtimeField(type?: string, script?: string, name?: string): RuntimeField;
 
     /**
      * Class supporting the Elasticsearch scripting API.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -167,7 +167,71 @@ declare namespace esb {
          */
         storedFields(fields: object | string): this;
 
-        runtimeMapping(runtimeMappingName: string, script: string | RuntimeField): this;
+
+
+        /**
+        * Computes a document property dynamically based on the supplied `runtimeField`.
+        *
+        * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html)
+        *
+        * Added in Elasticsearch v7.11.0
+        * [Release note](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.0.html)
+        *
+        * @example
+        * const reqBody = esb.requestBodySearch()
+        *     .query(esb.matchAllQuery())
+        *     .runtimeMapping(
+        *       'sessionId-name',
+        *       esb.runtimeField(
+        *         'keyword',
+        *         `emit(doc['session_id'].value + '::' + doc['name'].value)`
+        *       )
+        *     )
+        *
+        * @example
+        * // runtime fields can also be used in query aggregation
+        * const reqBody = esb.requestBodySearch()
+        *     .query(esb.matchAllQuery())
+        *     .runtimeMapping(
+        *       'sessionId-eventName',
+        *       esb.runtimeField(
+        *         'keyword',
+        *         `emit(doc['session_id'].value + '::' + doc['eventName'].value)`,
+        *       )
+        *     )
+        *     .agg(esb.cardinalityAggregation('uniqueCount', `sessionId-eventName`)),;
+        *
+        * @param {string} runtimeFieldName Name for the computed runtime mapping field.
+        * @param {RuntimeField} runtimeField Instance of RuntimeField
+        *
+        * @returns {RequestBodySearch} returns `this` so that calls can be chained
+        *
+        */
+        runtimeMapping(runtimeFieldName: string, runtimeField: RuntimeField): this;
+
+
+        /**
+        * Computes one or more document properties dynamically based on supplied `RuntimeField`s.
+        *
+        * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html)
+        *
+        * Added in Elasticsearch v7.11.0
+        * [Release note](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.0.html)
+        *
+        * @example
+        * const fieldA = esb.runtimeField(
+        *       'keyword',
+        *       `emit(doc['session_id'].value + '::' + doc['name'].value)`
+        * );
+        * const reqBody = esb.requestBodySearch()
+        *     .query(esb.matchAllQuery())
+        *     .runtimeMappings({
+        *       'sessionId-name': fieldA,
+        *     })
+        *
+        * @param {Object} runtimeMappings Object with `runtimeFieldName` as key and instance of `RuntimeField` as the value.
+        * @returns {RequestBodySearch} returns `this` so that calls can be chained
+        */
         runtimeMappings(runtimeMappings: object): this;
 
         /**
@@ -8764,11 +8828,39 @@ declare namespace esb {
      */
     export function highlight(fields?: string | string[]): Highlight;
 
+    /**
+    * Class supporting the Elasticsearch runtime field.
+    *
+    * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html)
+    *
+    * Added in Elasticsearch v7.11.0
+    * [Release note](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.0.html)
+    *
+    * @param {string=} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
+    * @param {string=} script Source of the script.
+    *
+    * @example
+    * const field = esb.runtimeField('keyword', `emit(doc['sessionId'].value + '::' + doc['name'].value)`);
+    */
     export class RuntimeField {
-        constructor(type?: string, script?: string, name?: string);
-        name(name: string);
+        constructor(type?: string, script?: string);
+
+        /**
+         * Sets the type of the runtime field.
+         * 
+         * @param {string} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
+         * @returns {void}
+         */
         type(type: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup');
+
+        /**
+         * Sets the source of the script.
+         * 
+         * @param {string} script
+         * @returns {void}
+         */
         script(script: string);
+
         /**
          * Override default `toJSON` to return DSL representation for the `script`.
          *
@@ -8776,7 +8868,22 @@ declare namespace esb {
          */
         toJSON(): object;
     }
-    export function runtimeField(type?: string, script?: string, name?: string): RuntimeField;
+
+    /**
+    * Class supporting the Elasticsearch runtime field.
+    *
+    * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html)
+    *
+    * Added in Elasticsearch v7.11.0
+    * [Release note](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.0.html)
+    *
+    * @param {string=} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
+    * @param {string=} script Source of the script.
+    *
+    * @example
+    * const field = esb.runtimeField('keyword', `emit(doc['sessionId'].value + '::' + doc['name'].value)`);
+    */
+    export function runtimeField(type?: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup', script?: string): RuntimeField;
 
     /**
      * Class supporting the Elasticsearch scripting API.

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const {
     Sort,
     Rescore,
     InnerHits,
+    RuntimeField,
     SearchTemplate,
     Query,
     util: { constructorWrapper }
@@ -639,6 +640,9 @@ exports.innerHits = constructorWrapper(InnerHits);
 
 exports.SearchTemplate = SearchTemplate;
 exports.searchTemplate = constructorWrapper(SearchTemplate);
+
+exports.RuntimeField = RuntimeField;
+exports.runtimeField = constructorWrapper(RuntimeField);
 
 exports.prettyPrint = function prettyPrint(obj) {
     console.log(JSON.stringify(obj, null, 2));

--- a/test/core-test/request-body-search.test.js
+++ b/test/core-test/request-body-search.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import test from 'ava';
 import {
     RequestBodySearch,
@@ -14,7 +15,8 @@ import {
     Script,
     Highlight,
     Rescore,
-    InnerHits
+    InnerHits,
+    RuntimeField
 } from '../../src';
 import { illegalParamType, makeSetsOptionMacro } from '../_macros';
 
@@ -36,6 +38,17 @@ const suggest = new TermSuggester(
 
 const sortChannel = new Sort('channel', 'desc');
 const sortCategories = new Sort('categories', 'desc');
+
+const runtimeFieldA = new RuntimeField(
+    'keyword',
+    "emit(doc['name'].value)",
+    'test1'
+);
+const runtimeFieldB = new RuntimeField(
+    'boolean',
+    "emit(doc['qty'].value > 10)",
+    'test2'
+);
 
 const scriptA = new Script('inline', "doc['my_field_name'].value * 2").lang(
     'painless'
@@ -131,6 +144,38 @@ test('sets stored_fields(arr) option', setsOption, 'storedFields', {
     param: ['user', 'postDate'],
     spread: false
 });
+
+test(setsOption, 'runtimeMapping', {
+    param: ['test1', runtimeFieldA],
+    propValue: {
+        test1: {
+            type: 'keyword',
+            script: {
+                source: "emit(doc['name'].value)"
+            }
+        }
+    },
+    keyName: 'runtime_mappings'
+});
+test(setsOption, 'runtimeMappings', {
+    param: { test1: runtimeFieldA, test2: runtimeFieldB },
+    propValue: {
+        test1: {
+            type: 'keyword',
+            script: {
+                source: "emit(doc['name'].value)"
+            }
+        },
+        test2: {
+            type: 'boolean',
+            script: {
+                source: "emit(doc['qty'].value > 10)"
+            }
+        }
+    },
+    keyName: 'runtime_mappings'
+});
+
 test(setsOption, 'scriptField', {
     param: ['test1', scriptA],
     propValue: { test1: { script: scriptA } },

--- a/test/core-test/request-body-search.test.js
+++ b/test/core-test/request-body-search.test.js
@@ -39,15 +39,10 @@ const suggest = new TermSuggester(
 const sortChannel = new Sort('channel', 'desc');
 const sortCategories = new Sort('categories', 'desc');
 
-const runtimeFieldA = new RuntimeField(
-    'keyword',
-    "emit(doc['name'].value)",
-    'test1'
-);
+const runtimeFieldA = new RuntimeField('keyword', "emit(doc['name'].value)");
 const runtimeFieldB = new RuntimeField(
     'boolean',
-    "emit(doc['qty'].value > 10)",
-    'test2'
+    "emit(doc['qty'].value > 10)"
 );
 
 const scriptA = new Script('inline', "doc['my_field_name'].value * 2").lang(

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -6,11 +6,6 @@ test('constructor set arguments', t => {
         'keyword',
         "emit(doc['name'].value)"
     ).toJSON();
-    const valueB = new RuntimeField(
-        'keyword',
-        "emit(doc['name'].value)"
-    ).toJSON();
-    t.deepEqual(valueA, valueB);
 
     const expected = {
         type: 'keyword',

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -39,3 +39,15 @@ test('type validate and set argument', t => {
         '`type` must be one of boolean, composite, date, double, geo_point, ip, keyword, long, lookup'
     );
 });
+
+test('script method sets script source', t => {
+    const fieldA = new RuntimeField('keyword');
+    fieldA.script("emit(doc['name'].value)");
+    const expected = {
+        type: 'keyword',
+        script: {
+            source: "emit(doc['name'].value)"
+        }
+    };
+    t.deepEqual(fieldA.toJSON(), expected);
+});

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -44,9 +44,3 @@ test('type validate and set argument', t => {
         '`type` must be one of boolean, composite, date, double, geo_point, ip, keyword, long, lookup'
     );
 });
-
-test('name set _name', t => {
-    const fieldA = new RuntimeField();
-    fieldA.name('field-name');
-    t.deepEqual(fieldA._name, 'field-name');
-});

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -1,0 +1,52 @@
+import test from 'ava';
+import RuntimeField from '../../src/core/runtime-field';
+
+test('constructor set arguments', t => {
+    const valueA = new RuntimeField(
+        'keyword',
+        "emit(doc['name'].value)"
+    ).toJSON();
+    const valueB = new RuntimeField(
+        'keyword',
+        "emit(doc['name'].value)"
+    ).toJSON();
+    t.deepEqual(valueA, valueB);
+
+    const expected = {
+        type: 'keyword',
+        script: {
+            source: "emit(doc['name'].value)"
+        }
+    };
+    t.deepEqual(valueA, expected);
+
+    let err = t.throws(() => new RuntimeField().toJSON(), Error);
+    t.is(err.message, '`type` should be set');
+
+    err = t.throws(() => new RuntimeField('keyword').toJSON(), Error);
+    t.is(err.message, '`script` should be set');
+});
+
+test('type validate and set argument', t => {
+    const fieldA = new RuntimeField('keyword', "emit(doc['name'].value)");
+    fieldA.type('boolean');
+    const expected = {
+        type: 'boolean',
+        script: {
+            source: "emit(doc['name'].value)"
+        }
+    };
+    t.deepEqual(fieldA.toJSON(), expected);
+
+    const err = t.throws(() => fieldA.type('invalid'), Error);
+    t.is(
+        err.message,
+        '`type` must be one of boolean, composite, date, double, geo_point, ip, keyword, long, lookup'
+    );
+});
+
+test('name set _name', t => {
+    const fieldA = new RuntimeField();
+    fieldA.name('field-name');
+    t.deepEqual(fieldA._name, 'field-name');
+});


### PR DESCRIPTION
### Issue:

resolves #152 

### Additional Author

Original [PR](https://github.com/sudo-suhas/elastic-builder/pull/165) was raised by @jmaitrehenry but appears to be abandoned. This PR attempts to complete implementation of this feature, based upon his original work.

### Aim:

Add support for Elasticsearch `runtime_mappings` field, added in [v7.11.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.0.html).

Usage:
```
const field = esb.runtimeField(
      'keyword',
      `emit(doc['sessionId'].value + '::' + doc['name'].value)`,
);
const reqBody = esb.requestBodySearch();
reqBody.runtimeMapping('sessionId-eventName', field);
```

Will generate query:
```
{
  "runtime_mappings": {
    "sessionId-eventName": {
      "type": "keyword",
      "script": {
        "source": "emit(doc['sessionId'].value + '::' + doc['name'].value)"
      }
    }
  }
}
```


### Changes from original PR

- Removed `name` property from RuntimeField class. It, as far as I could tell, didn't do anything. The name for the runtime field is set as the first param of `runtimeMapping`.
- Updated and expanded JSDocs.
- Expanded typing.
- Renamed some variables.