### PR TITLE
fix: runtime field class methods return types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8926,7 +8926,7 @@ declare namespace esb {
          * @param {string} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
          * @returns {void}
          */
-        type(type: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup');
+        type(type: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup'): void;
 
         /**
          * Sets the source of the script.
@@ -8934,7 +8934,7 @@ declare namespace esb {
          * @param {string} script
          * @returns {void}
          */
-        script(script: string);
+        script(script: string): void;
 
         /**
          * Override default `toJSON` to return DSL representation for the `script`.


### PR DESCRIPTION
There was a mismatch between the return types as defined in the JSDoc comments and the implicit return types inferred by TypeScript:

<img width="1835" alt="elastic-builder-type-error" src="https://github.com/sudo-suhas/elastic-builder/assets/7498459/bd64e5a5-ed5a-4266-83a5-f342c4c8e034">
