### PR TITLE
Runtime field script params

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "kennylindahl <haxxblaster@gmail.com>",
     "foxstarius <aj.franzon@gmail.com>",
     "sandeep952 <sandy335582@gmail.com>",
-    "florian-lackner365 <florian.lackner@365talents.com>"
+    "florian-lackner365 <florian.lackner@365talents.com>",
+    "Alejandro Marulanda <alejokf@gmail.com>"
   ]
 }

--- a/src/core/runtime-field.js
+++ b/src/core/runtime-field.js
@@ -33,6 +33,7 @@ class RuntimeField {
         this._body = {};
         this._isTypeSet = false;
         this._isScriptSet = false;
+        this._isParamsSet = false;
 
         if (!isNil(type)) {
             this.type(type);
@@ -46,19 +47,20 @@ class RuntimeField {
     /**
      * Sets the source of the script.
      * @param {string} script
-     * @returns {void}
+     * @returns {RuntimeField} returns `this` so that calls can be chained.
      */
     script(script) {
         this._body.script = {
             source: script
         };
         this._isScriptSet = true;
+        return this;
     }
 
     /**
      * Sets the type of the runtime field.
      * @param {string} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
-     * @returns {void}
+     * @returns {RuntimeField} returns `this` so that calls can be chained.
      */
     type(type) {
         const typeLower = type.toLowerCase();
@@ -67,6 +69,30 @@ class RuntimeField {
         }
         this._body.type = typeLower;
         this._isTypeSet = true;
+        return this;
+    }
+
+    /**
+     * Specifies the language the script is written in. Defaults to `painless` but
+     * may be set to any of languages listed in [Scripting](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html).
+     *
+     * @param {string} lang The language for the script.
+     * @returns {RuntimeField} returns `this` so that calls can be chained.
+     */
+    lang(lang) {
+        this._body.lang = lang;
+        return this;
+    }
+
+    /**
+     * Specifies any named parameters that are passed into the script as variables.
+     *
+     * @param {Object} params Named parameters to be passed to script.
+     * @returns {RuntimeField} returns `this` so that calls can be chained.
+     */
+    params(params) {
+        this._body.params = params;
+        return this;
     }
 
     /**

--- a/src/core/runtime-field.js
+++ b/src/core/runtime-field.js
@@ -33,7 +33,6 @@ class RuntimeField {
         this._body = {};
         this._isTypeSet = false;
         this._isScriptSet = false;
-        this._isParamsSet = false;
 
         if (!isNil(type)) {
             this.type(type);

--- a/src/core/runtime-field.js
+++ b/src/core/runtime-field.js
@@ -80,7 +80,9 @@ class RuntimeField {
      * @returns {RuntimeField} returns `this` so that calls can be chained.
      */
     lang(lang) {
-        this._body.lang = lang;
+        if (!isNil(this._body.script)) {
+            this._body.script.lang = lang;
+        }
         return this;
     }
 
@@ -91,7 +93,9 @@ class RuntimeField {
      * @returns {RuntimeField} returns `this` so that calls can be chained.
      */
     params(params) {
-        this._body.params = params;
+        if (!isNil(this._body.script)) {
+            this._body.script.params = params;
+        }
         return this;
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8924,17 +8924,34 @@ declare namespace esb {
          * Sets the type of the runtime field.
          * 
          * @param {string} type One of `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
-         * @returns {void}
+         * @returns {RuntimeField} returns `this` so that calls can be chained.
          */
-        type(type: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup'): void;
+        type(type: 'boolean' | 'composite' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long' | 'lookup'): this;
 
         /**
          * Sets the source of the script.
          * 
-         * @param {string} script
-         * @returns {void}
+         * @param {string} script 
+         * @returns {RuntimeField} returns `this` so that calls can be chained.
          */
-        script(script: string): void;
+        script(script: string): this;
+
+        /**
+         * Specifies the language the script is written in. Defaults to `painless` but
+         * may be set to any of languages listed in [Scripting](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html).
+         *
+         * @param {string} lang The language for the script.
+         * @returns {RuntimeField} returns `this` so that calls can be chained.
+         */
+        lang(lang: string): this;
+    
+        /**
+         * Specifies any named parameters that are passed into the script as variables.
+         *
+         * @param {object} params Named parameters to be passed to script.
+         * @returns {RuntimeField} returns `this` so that calls can be chained.
+         */
+        params(params: object): this;
 
         /**
          * Override default `toJSON` to return DSL representation for the `script`.

--- a/test/core-test/request-body-search.test.js
+++ b/test/core-test/request-body-search.test.js
@@ -181,12 +181,12 @@ test('Runtime mappging with lang and params', setsOption, 'runtimeMapping', {
     propValue: {
         test1: {
             type: 'keyword',
-            lang: 'painless',
             script: {
-                source: "emit(doc['my_field_name'].value * params.factor)"
-            },
-            params: {
-                factor: 2.0
+                lang: 'painless',
+                source: "emit(doc['my_field_name'].value * params.factor)",
+                params: {
+                    factor: 2.0
+                }
             }
         }
     },

--- a/test/core-test/request-body-search.test.js
+++ b/test/core-test/request-body-search.test.js
@@ -44,6 +44,12 @@ const runtimeFieldB = new RuntimeField(
     'boolean',
     "emit(doc['qty'].value > 10)"
 );
+const runtimeFieldC = new RuntimeField(
+    'keyword',
+    "emit(doc['my_field_name'].value * params.factor)"
+)
+    .lang('painless')
+    .params({ factor: 2.0 });
 
 const scriptA = new Script('inline', "doc['my_field_name'].value * 2").lang(
     'painless'
@@ -165,6 +171,22 @@ test(setsOption, 'runtimeMappings', {
             type: 'boolean',
             script: {
                 source: "emit(doc['qty'].value > 10)"
+            }
+        }
+    },
+    keyName: 'runtime_mappings'
+});
+test('Runtime mappging with lang and params', setsOption, 'runtimeMapping', {
+    param: ['test1', runtimeFieldC],
+    propValue: {
+        test1: {
+            type: 'keyword',
+            lang: 'painless',
+            script: {
+                source: "emit(doc['my_field_name'].value * params.factor)"
+            },
+            params: {
+                factor: 2.0
             }
         }
     },

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -51,3 +51,21 @@ test('script method sets script source', t => {
     };
     t.deepEqual(fieldA.toJSON(), expected);
 });
+
+test('set script, lang and params', t => {
+    const fieldA = new RuntimeField('keyword');
+    fieldA.script("emit(doc['my_field_name'].value * params.factor)");
+    fieldA.lang('painless');
+    fieldA.params({ factor: 2.0 });
+    const expected = {
+        type: 'keyword',
+        lang: 'painless',
+        script: {
+            source: "emit(doc['my_field_name'].value * params.factor)"
+        },
+        params: {
+            factor: 2.0
+        }
+    };
+    t.deepEqual(fieldA.toJSON(), expected);
+});

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -69,3 +69,11 @@ test('set script, lang and params', t => {
     };
     t.deepEqual(fieldA.toJSON(), expected);
 });
+
+test("don't set lang and params if script is not set", t => {
+    const fieldA = new RuntimeField('keyword');
+    fieldA.lang('painless');
+    fieldA.params({ factor: 2.0 });
+    const error = t.throws(() => fieldA.toJSON());
+    t.is(error.message, '`script` should be set');
+});

--- a/test/core-test/runtime-field.test.js
+++ b/test/core-test/runtime-field.test.js
@@ -59,12 +59,12 @@ test('set script, lang and params', t => {
     fieldA.params({ factor: 2.0 });
     const expected = {
         type: 'keyword',
-        lang: 'painless',
         script: {
-            source: "emit(doc['my_field_name'].value * params.factor)"
-        },
-        params: {
-            factor: 2.0
+            lang: 'painless',
+            source: "emit(doc['my_field_name'].value * params.factor)",
+            params: {
+                factor: 2.0
+            }
         }
     };
     t.deepEqual(fieldA.toJSON(), expected);


### PR DESCRIPTION
### Issue
resolves https://github.com/sudo-suhas/elastic-builder/issues/201

### Goal
Add support for Elasticsearch lang and params fields in runtime_mappings' script

### Usage
This Typescript code:
```
const params = {
   factor: 2
}
const field = esb.runtimeField("long", "emit(doc['measure'].value * params.factor);")
  .lang('painless')
  .params(params)
const reqBody = esb.requestBodySearch();
reqBody.runtimeMapping('measure', field);
```
Will generate this query:
```
{
  "runtime_mappings": {
    "measure": {
      "type": "long",
      "script": {
        "lang": "painless",
        "source": "emit(doc['measure'].value * params.factor);",
        "params": {
          "factor": 2
        }
      }
    }
  }
}
```

### Changes in PR

- Add lang field to RuntimeField
- Add params field to RuntimeField
- Add unit tests
- Make RuntimeField return this to allow calls being chained and to make the it consistent with the rest of the API, as suggested  on [this comment](https://github.com/sudo-suhas/elastic-builder/pull/200#issuecomment-2054078945).