### PR TITLE
Fix nested script object

### DIFF
--- a/src/queries/specialized-queries/script-query.js
+++ b/src/queries/specialized-queries/script-query.js
@@ -43,7 +43,7 @@ class ScriptQuery extends Query {
     script(script) {
         checkType(script, Script);
 
-        this._queryOpts.script = script;
+        this._body.script = script;
         return this;
     }
 }


### PR DESCRIPTION
Used the _body property directly instead of _queryOpts because of an issue with script objects appearing as nested when doing toJSON.

As-Is
```
{"script": {"script": "..." }}
```

To-Be
```
{"script":"..."}
```