### PR TITLE
fix: stop using single-function Lodash packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash.has": "^4.5.2",
-    "lodash.hasin": "^4.5.2",
-    "lodash.head": "^4.0.1",
-    "lodash.isempty": "^4.4.0",
-    "lodash.isnil": "^4.0.0",
-    "lodash.isobject": "^3.0.2",
-    "lodash.isstring": "^4.0.1",
-    "lodash.omit": "^4.5.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "ava": "^0.25.0",
@@ -54,7 +47,6 @@
     "eslint-plugin-prettier": "^2.6.2",
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
-    "lodash": "^4.17.10",
     "nyc": "^12.0.2",
     "prettier": "^1.13.7",
     "sinon": "^6.1.3",

--- a/src/aggregations/bucket-aggregations/auto-date-histogram-aggregation.js
+++ b/src/aggregations/bucket-aggregations/auto-date-histogram-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/bucket-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/bucket-aggregation-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Aggregation,

--- a/src/aggregations/bucket-aggregations/composite-agg-values-sources/date-histogram-values-source.js
+++ b/src/aggregations/bucket-aggregations/composite-agg-values-sources/date-histogram-values-source.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const ValuesSourceBase = require('./values-source-base');
 

--- a/src/aggregations/bucket-aggregations/composite-agg-values-sources/histogram-values-source.js
+++ b/src/aggregations/bucket-aggregations/composite-agg-values-sources/histogram-values-source.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const ValuesSourceBase = require('./values-source-base');
 

--- a/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
+++ b/src/aggregations/bucket-aggregations/composite-agg-values-sources/values-source-base.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const isEmpty = require('lodash.isempty');
-const isNil = require('lodash.isnil');
+const { isEmpty, isNil } = require('lodash');
 
 const {
     util: { invalidParam, recursiveToJSON }

--- a/src/aggregations/bucket-aggregations/diversified-sampler-aggregation.js
+++ b/src/aggregations/bucket-aggregations/diversified-sampler-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam },

--- a/src/aggregations/bucket-aggregations/filter-aggregation.js
+++ b/src/aggregations/bucket-aggregations/filter-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/aggregations/bucket-aggregations/filters-aggregation.js
+++ b/src/aggregations/bucket-aggregations/filters-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isEmpty = require('lodash.isempty');
+const { isEmpty } = require('lodash');
 
 const {
     Query,

--- a/src/aggregations/bucket-aggregations/geo-distance-aggregation.js
+++ b/src/aggregations/bucket-aggregations/geo-distance-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     GeoPoint,

--- a/src/aggregations/bucket-aggregations/geo-hash-grid-aggregation.js
+++ b/src/aggregations/bucket-aggregations/geo-hash-grid-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/geo-hex-grid-aggregation.js
+++ b/src/aggregations/bucket-aggregations/geo-hex-grid-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/geo-tile-grid-aggregation.js
+++ b/src/aggregations/bucket-aggregations/geo-tile-grid-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     GeoPoint,

--- a/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/histogram-aggregation-base.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const isNil = require('lodash.isnil');
+const { has, isNil } = require('lodash');
 
 const {
     util: { invalidParam }

--- a/src/aggregations/bucket-aggregations/nested-aggregation.js
+++ b/src/aggregations/bucket-aggregations/nested-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/parent-aggregation.js
+++ b/src/aggregations/bucket-aggregations/parent-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/range-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/range-aggregation-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isEmpty = require('lodash.isempty');
+const { isEmpty } = require('lodash');
 
 const {
     util: { checkType }

--- a/src/aggregations/bucket-aggregations/rare-terms-aggregation.js
+++ b/src/aggregations/bucket-aggregations/rare-terms-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/reverse-nested-aggregation.js
+++ b/src/aggregations/bucket-aggregations/reverse-nested-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/bucket-aggregations/terms-aggregation-base.js
+++ b/src/aggregations/bucket-aggregations/terms-aggregation-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam },

--- a/src/aggregations/bucket-aggregations/terms-aggregation.js
+++ b/src/aggregations/bucket-aggregations/terms-aggregation.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const isNil = require('lodash.isnil');
+const { has, isNil } = require('lodash');
 
 const {
     util: { invalidParam }

--- a/src/aggregations/bucket-aggregations/variable-width-histogram-aggregation.js
+++ b/src/aggregations/bucket-aggregations/variable-width-histogram-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const BucketAggregationBase = require('./bucket-aggregation-base');
 

--- a/src/aggregations/matrix-aggregations/matrix-stats-aggregation.js
+++ b/src/aggregations/matrix-aggregations/matrix-stats-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Aggregation,

--- a/src/aggregations/metrics-aggregations/metrics-aggregation-base.js
+++ b/src/aggregations/metrics-aggregations/metrics-aggregation-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Aggregation,

--- a/src/aggregations/metrics-aggregations/percentile-ranks-aggregation.js
+++ b/src/aggregations/metrics-aggregations/percentile-ranks-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType }

--- a/src/aggregations/metrics-aggregations/weighted-average-aggregation.js
+++ b/src/aggregations/metrics-aggregations/weighted-average-aggregation.js
@@ -2,7 +2,7 @@
 
 const { Script } = require('../../core');
 const MetricsAggregationBase = require('./metrics-aggregation-base');
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const ES_REF_URL =
     'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-weight-avg-aggregation.html';

--- a/src/aggregations/pipeline-aggregations/moving-average-aggregation.js
+++ b/src/aggregations/pipeline-aggregations/moving-average-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam },

--- a/src/aggregations/pipeline-aggregations/moving-function-aggregation.js
+++ b/src/aggregations/pipeline-aggregations/moving-function-aggregation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const PipelineAggregationBase = require('./pipeline-aggregation-base');
 

--- a/src/aggregations/pipeline-aggregations/pipeline-aggregation-base.js
+++ b/src/aggregations/pipeline-aggregations/pipeline-aggregation-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Aggregation,

--- a/src/core/aggregation.js
+++ b/src/core/aggregation.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const isEmpty = require('lodash.isempty');
+const { has, isEmpty } = require('lodash');
 
 const { checkType, recursiveToJSON } = require('./util');
 

--- a/src/core/geo-point.js
+++ b/src/core/geo-point.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const isObject = require('lodash.isobject');
-const isNil = require('lodash.isnil');
+const { isObject, isNil } = require('lodash');
 
 const { checkType } = require('./util');
 

--- a/src/core/geo-shape.js
+++ b/src/core/geo-shape.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
-const has = require('lodash.has');
+const { isNil, has } = require('lodash');
 
 const { checkType, invalidParam } = require('./util');
 const { GEO_SHAPE_TYPES } = require('./consts');

--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const has = require('lodash.has'),
-    isEmpty = require('lodash.isempty'),
-    isNil = require('lodash.isnil'),
-    isString = require('lodash.isstring');
-
+const { has, isEmpty, isNil, isString } = require('lodash');
 const Query = require('./query');
 const { checkType, invalidParam, recursiveToJSON } = require('./util');
 

--- a/src/core/indexed-shape.js
+++ b/src/core/indexed-shape.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 /**
  * A shape which has already been indexed in another index and/or index

--- a/src/core/inner-hits.js
+++ b/src/core/inner-hits.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const Sort = require('./sort');
 const Highlight = require('./highlight');

--- a/src/core/inspect.js
+++ b/src/core/inspect.js
@@ -2,8 +2,7 @@
 /* eslint-disable max-lines */
 'use strict';
 
-const isString = require('lodash.isstring'),
-    isObject = require('lodash.isobject');
+const { isString, isObject } = require('lodash');
 
 /**
  * Echos the value of a value. Trys to print the value out

--- a/src/core/request-body-search.js
+++ b/src/core/request-body-search.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const has = require('lodash.has'),
-    isNil = require('lodash.isnil'),
-    isEmpty = require('lodash.isempty');
+const { has, isNil, isEmpty } = require('lodash');
 
 const Query = require('./query'),
     Aggregation = require('./aggregation'),

--- a/src/core/rescore.js
+++ b/src/core/rescore.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const Query = require('./query');
 const { checkType, invalidParam, recursiveToJSON } = require('./util');

--- a/src/core/runtime-field.js
+++ b/src/core/runtime-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 const validType = [
     'boolean',
     'composite',

--- a/src/core/script.js
+++ b/src/core/script.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 /**
  * Class supporting the Elasticsearch scripting API.

--- a/src/core/search-template.js
+++ b/src/core/search-template.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const { recursiveToJSON } = require('./util');
 

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const isEmpty = require('lodash.isempty');
-const has = require('lodash.has');
-const isNil = require('lodash.isnil');
+const { isEmpty, has, isNil } = require('lodash');
 
 const Query = require('./query');
 const Script = require('./script');

--- a/src/core/suggester.js
+++ b/src/core/suggester.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
-
-const isEmpty = require('lodash.isempty');
+const { isNil, isEmpty } = require('lodash');
 
 /**
  * Base class implementation for all suggester types.

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -1,11 +1,6 @@
 'use strict';
 
-const isEmpty = require('lodash.isempty'),
-    isNil = require('lodash.isnil'),
-    isString = require('lodash.isstring'),
-    isObject = require('lodash.isobject'),
-    hasIn = require('lodash.hasin'),
-    has = require('lodash.has');
+const { isEmpty, isNil, isString, isObject, hasIn, has } = require('lodash');
 
 const inspect = require('./inspect');
 

--- a/src/queries/compound-queries/bool-query.js
+++ b/src/queries/compound-queries/bool-query.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const head = require('lodash.head');
-const omit = require('lodash.omit');
+const { has, head, omit } = require('lodash');
 
 const {
     Query,

--- a/src/queries/compound-queries/boosting-query.js
+++ b/src/queries/compound-queries/boosting-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/compound-queries/constant-score-query.js
+++ b/src/queries/compound-queries/constant-score-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/compound-queries/function-score-query.js
+++ b/src/queries/compound-queries/function-score-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/compound-queries/score-functions/decay-score-function.js
+++ b/src/queries/compound-queries/score-functions/decay-score-function.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam, recursiveToJSON }

--- a/src/queries/compound-queries/score-functions/field-value-factor-function.js
+++ b/src/queries/compound-queries/score-functions/field-value-factor-function.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam },

--- a/src/queries/compound-queries/score-functions/script-score-function.js
+++ b/src/queries/compound-queries/score-functions/script-score-function.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const ScoreFunction = require('./score-function');
 

--- a/src/queries/compound-queries/score-functions/weight-score-function.js
+++ b/src/queries/compound-queries/score-functions/weight-score-function.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const ScoreFunction = require('./score-function');
 

--- a/src/queries/full-text-queries/combined-fields-query.js
+++ b/src/queries/full-text-queries/combined-fields-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType, invalidParam }

--- a/src/queries/full-text-queries/common-terms-query.js
+++ b/src/queries/full-text-queries/common-terms-query.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
-const isObject = require('lodash.isobject');
+const { isNil, isObject } = require('lodash');
 
 const {
     util: { invalidParam, setDefault }

--- a/src/queries/full-text-queries/full-text-query-base.js
+++ b/src/queries/full-text-queries/full-text-query-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const { Query } = require('../../core');
 

--- a/src/queries/full-text-queries/match-query.js
+++ b/src/queries/full-text-queries/match-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam }

--- a/src/queries/full-text-queries/mono-field-query-base.js
+++ b/src/queries/full-text-queries/mono-field-query-base.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const isNil = require('lodash.isnil');
+const { has, isNil } = require('lodash');
 
 const FullTextQueryBase = require('./full-text-query-base');
 

--- a/src/queries/full-text-queries/multi-match-query.js
+++ b/src/queries/full-text-queries/multi-match-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType, invalidParam },

--- a/src/queries/full-text-queries/query-string-query-base.js
+++ b/src/queries/full-text-queries/query-string-query-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType, setDefault, invalidParam }

--- a/src/queries/geo-queries/geo-bounding-box-query.js
+++ b/src/queries/geo-queries/geo-bounding-box-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     GeoPoint,

--- a/src/queries/geo-queries/geo-distance-query.js
+++ b/src/queries/geo-queries/geo-distance-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     GeoPoint,

--- a/src/queries/geo-queries/geo-query-base.js
+++ b/src/queries/geo-queries/geo-query-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/geo-queries/geo-shape-query.js
+++ b/src/queries/geo-queries/geo-shape-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     GeoShape,

--- a/src/queries/joining-queries/has-child-query.js
+++ b/src/queries/joining-queries/has-child-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const JoiningQueryBase = require('./joining-query-base');
 

--- a/src/queries/joining-queries/has-parent-query.js
+++ b/src/queries/joining-queries/has-parent-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const JoiningQueryBase = require('./joining-query-base');
 

--- a/src/queries/joining-queries/joining-query-base.js
+++ b/src/queries/joining-queries/joining-query-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/joining-queries/nested-query.js
+++ b/src/queries/joining-queries/nested-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const JoiningQueryBase = require('./joining-query-base');
 

--- a/src/queries/joining-queries/parent-id-query.js
+++ b/src/queries/joining-queries/parent-id-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const { Query } = require('../../core');
 

--- a/src/queries/span-queries/span-field-masking-query.js
+++ b/src/queries/span-queries/span-field-masking-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType }

--- a/src/queries/span-queries/span-first-query.js
+++ b/src/queries/span-queries/span-first-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType }

--- a/src/queries/span-queries/span-multi-term-query.js
+++ b/src/queries/span-queries/span-multi-term-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType }

--- a/src/queries/span-queries/span-term-query.js
+++ b/src/queries/span-queries/span-term-query.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const isNil = require('lodash.isnil');
+const { has, isNil } = require('lodash');
 
 const SpanQueryBase = require('./span-query-base');
 

--- a/src/queries/specialized-queries/distance-feature-query.js
+++ b/src/queries/specialized-queries/distance-feature-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 const { Query } = require('../../core');
 
 /**

--- a/src/queries/specialized-queries/more-like-this-query.js
+++ b/src/queries/specialized-queries/more-like-this-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
+const { has } = require('lodash');
 
 const {
     Query,

--- a/src/queries/specialized-queries/percolate-query.js
+++ b/src/queries/specialized-queries/percolate-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType },

--- a/src/queries/specialized-queries/rank-feature-query.js
+++ b/src/queries/specialized-queries/rank-feature-query.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Query } = require('../../core');
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 /**
  * The rank_feature query boosts the relevance score on the numeric value of

--- a/src/queries/specialized-queries/script-query.js
+++ b/src/queries/specialized-queries/script-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/term-level-queries/exists-query.js
+++ b/src/queries/term-level-queries/exists-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const { Query } = require('../../core');
 

--- a/src/queries/term-level-queries/ids-query.js
+++ b/src/queries/term-level-queries/ids-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/term-level-queries/range-query.js
+++ b/src/queries/term-level-queries/range-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { invalidParam },

--- a/src/queries/term-level-queries/terms-query.js
+++ b/src/queries/term-level-queries/terms-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     util: { checkType }

--- a/src/queries/term-level-queries/terms-set-query.js
+++ b/src/queries/term-level-queries/terms-set-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     Query,

--- a/src/queries/term-level-queries/type-query.js
+++ b/src/queries/term-level-queries/type-query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const { Query } = require('../../core');
 

--- a/src/queries/term-level-queries/value-term-query-base.js
+++ b/src/queries/term-level-queries/value-term-query-base.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const has = require('lodash.has');
-const isNil = require('lodash.isnil');
+const { has, isNil } = require('lodash');
 
 const { Query } = require('../../core');
 

--- a/src/recipes.js
+++ b/src/recipes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     MatchAllQuery,

--- a/src/suggesters/analyzed-suggester-base.js
+++ b/src/suggesters/analyzed-suggester-base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const { Suggester } = require('../core');
 

--- a/src/suggesters/completion-suggester.js
+++ b/src/suggesters/completion-suggester.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isObject = require('lodash.isobject');
+const { isObject } = require('lodash');
 
 const {
     Suggester,

--- a/src/suggesters/direct-generator.js
+++ b/src/suggesters/direct-generator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     consts: { SUGGEST_MODE_SET },

--- a/src/suggesters/phase-suggester.js
+++ b/src/suggesters/phase-suggester.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     consts: { SMOOTHING_MODEL_SET },

--- a/src/suggesters/phrase-suggester.js
+++ b/src/suggesters/phrase-suggester.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     consts: { SMOOTHING_MODEL_SET },

--- a/src/suggesters/term-suggester.js
+++ b/src/suggesters/term-suggester.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isNil = require('lodash.isnil');
+const { isNil } = require('lodash');
 
 const {
     consts: { SUGGEST_MODE_SET, STRING_DISTANCE_SET },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5109,45 +5109,10 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.has@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
-  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
-
-lodash.hasin@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.hasin/-/lodash.hasin-4.5.2.tgz#f91e352378d21ef7090b9e7687c2ca35c5b4d52a"
-  integrity sha1-+R41I3jSHvcJC552h8LKNcW01So=
-
-lodash.head@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.head/-/lodash.head-4.0.1.tgz#e2aa322d3ec40cd6aae186082977d993b354ed9c"
-  integrity sha1-4qoyLT7EDNaq4YYIKXfZk7NU7Zw=
-
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
-lodash.isnil@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
-  integrity sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw=
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
-
-lodash.isstring@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
-  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.kebabcase@^4.0.1:
   version "4.1.1"
@@ -5158,11 +5123,6 @@ lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
 lodash.snakecase@^4.0.1:
   version "4.1.1"
@@ -5179,7 +5139,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Closes #199, #209

> The single-function Lodash packages are [deprecated](https://lodash.com/per-method-packages) and not maintained anymore, so they don't receive bugfixes or security patches (as already mentioned in #199). Also, as already mentioned in multiple places, both the modern tree-shaking implementations and the fact that many libraries use full Lodash anyway (either directly or transitively) makes the usage of single-function Lodash packages unjustified.