### PR TITLE
feat: add TypeScript definitions for CombinedFieldsQuery

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1392,6 +1392,108 @@ declare namespace esb {
     ): SimpleQueryStringQuery;
 
     /**
+     * The `combined_fields` query supports searching multiple text fields as if
+     * their contents had been indexed into one combined field. It takes a term-centric
+     * view of the query: first it analyzes the query string to produce individual terms,
+     * then looks for each term in any of the fields.
+     *
+     * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html)
+     *
+     * NOTE: This query was added in elasticsearch v7.13.
+     *
+     * @param {Array<string>|string=} fields The fields to be queried
+     * @param {string=} queryString The query string
+     * @extends FullTextQueryBase
+     */
+    export class CombinedFieldsQuery extends FullTextQueryBase {
+        constructor(fields?: string[] | string, queryString?: string);
+
+        /**
+         * Appends given field to the list of fields to search against.
+         * Fields can be specified with wildcards.
+         * Individual fields can be boosted with the caret (^) notation.
+         * Example - `"subject^3"`
+         *
+         * @param {string} field One of the fields to be queried
+         * @returns {CombinedFieldsQuery} returns `this` so that calls can be chained.
+         */
+        field(field: string): this;
+
+        /**
+         * Appends given fields to the list of fields to search against.
+         * Fields can be specified with wildcards.
+         * Individual fields can be boosted with the caret (^) notation.
+         *
+         * @example
+         * // Boost individual fields with caret `^` notation
+         * const qry = esb.combinedFieldsQuery(['subject^3', 'message'], 'this is a test');
+         *
+         * @example
+         * // Specify fields with wildcards
+         * const qry = esb.combinedFieldsQuery(['title', '*_name'], 'Will Smith');
+         *
+         * @param {Array<string>} fields The fields to be queried
+         * @returns {CombinedFieldsQuery} returns `this` so that calls can be chained.
+         */
+        fields(fields: string[]): this;
+
+        /**
+         * If true, match phrase queries are automatically created for multi-term synonyms.
+         *
+         * @param {boolean} enable Defaults to `true`
+         * @returns {CombinedFieldsQuery} returns `this` so that calls can be chained.
+         */
+        autoGenerateSynonymsPhraseQuery(enable: boolean): this;
+
+        /**
+         * The operator to be used in the boolean query which is constructed
+         * by analyzing the text provided. The `operator` flag can be set to `or` or
+         * `and` to control the boolean clauses (defaults to `or`).
+         *
+         * @param {string} operator Can be `and`/`or`. Default is `or`.
+         * @returns {CombinedFieldsQuery} returns `this` so that calls can be chained.
+         */
+        operator(operator: 'and' | 'or'): this;
+
+        /**
+         * If the analyzer used removes all tokens in a query like a `stop` filter does,
+         * the default behavior is to match no documents at all. In order to change that
+         * the `zero_terms_query` option can be used, which accepts `none` (default) and `all`
+         * which corresponds to a `match_all` query.
+         *
+         * @example
+         * const qry = esb.combinedFieldsQuery('message', 'to be or not to be')
+         *     .operator('and')
+         *     .zeroTermsQuery('all');
+         *
+         * @param {string} behavior A no match action, `all` or `none`. Default is `none`.
+         * @returns {CombinedFieldsQuery} returns `this` so that calls can be chained.
+         */
+        zeroTermsQuery(behavior: 'all' | 'none'): this;
+    }
+
+    /**
+     * The `combined_fields` query supports searching multiple text fields as if
+     * their contents had been indexed into one combined field. It takes a term-centric
+     * view of the query: first it analyzes the query string to produce individual terms,
+     * then looks for each term in any of the fields.
+     *
+     * [Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html)
+     *
+     * NOTE: This query was added in elasticsearch v7.13.
+     *
+     * @example
+     * const qry = esb.combinedFieldsQuery(['subject', 'message'], 'this is a test');
+     *
+     * @param {Array<string>|string=} fields The fields to be queried
+     * @param {string=} queryString The query string
+     */
+    export function combinedFieldsQuery(
+        fields?: string[] | string,
+        queryString?: string
+    ): CombinedFieldsQuery;
+
+    /**
      * The `ValueTermQueryBase` provides support for common options used across
      * various term level query implementations.
      *

--- a/test/typedef.test.ts
+++ b/test/typedef.test.ts
@@ -22,6 +22,33 @@ esb
             .minimumShouldMatch('30%')
     );
 
+// Combined Fields Query
+esb
+    .requestBodySearch()
+    .query(
+        esb
+            .combinedFieldsQuery(['title', 'body'], 'Quick brown fox')
+            .operator('and')
+            .autoGenerateSynonymsPhraseQuery(true)
+            .zeroTermsQuery('all')
+    );
+
+// Combined Fields Query with single field
+esb
+    .requestBodySearch()
+    .query(
+        esb
+            .combinedFieldsQuery('title', 'Quick brown fox')
+            .field('description')
+            .fields(['tags', 'content^2'])
+    );
+
+// Combined Fields Query - class constructor
+new esb.CombinedFieldsQuery(['title', 'content'], 'search terms')
+    .operator('or')
+    .autoGenerateSynonymsPhraseQuery(false)
+    .toJSON();
+
 // Percolate Query
 esb
     .requestBodySearch()


### PR DESCRIPTION
## Description

This PR adds missing TypeScript definitions for `CombinedFieldsQuery` in `src/index.d.ts`. The JavaScript implementation already exists and is exported properly, but TypeScript users were unable to use this query type due to missing type definitions.

## Changes

- ✨ Added `CombinedFieldsQuery` class definition with all methods and proper typing
- ✨ Added `combinedFieldsQuery` factory function definition  
- ✨ Added comprehensive JSDoc comments with examples
- ✅ Added TypeScript test cases in `test/typedef.test.ts`

## Type Definitions Added

### Class Definition
```typescript
export class CombinedFieldsQuery extends FullTextQueryBase {
    constructor(fields?: string[] | string, queryString?: string);
    field(field: string): this;
    fields(fields: string[]): this;
    autoGenerateSynonymsPhraseQuery(enable: boolean): this;
    operator(operator: 'and' | 'or'): this;
    zeroTermsQuery(behavior: 'all' | 'none'): this;
}
```

### Factory Function
```typescript
export function combinedFieldsQuery(
    fields?: string[] | string,
    queryString?: string
): CombinedFieldsQuery;
```

## Testing

- ✅ All existing tests pass
- ✅ TypeScript compilation succeeds without errors
- ✅ New TypeScript test cases added and passing
- ✅ 100% code coverage maintained

## Usage Example

```typescript
import * as esb from 'elastic-builder';

// Factory function
const query1 = esb.combinedFieldsQuery(['title', 'body'], 'Quick brown fox')
    .operator('and')
    .autoGenerateSynonymsPhraseQuery(true);

// Class constructor
const query2 = new esb.CombinedFieldsQuery(['title', 'content'], 'search terms')
    .zeroTermsQuery('all');
```

## Fixes

Resolves TypeScript compilation errors when using `CombinedFieldsQuery` in TypeScript projects.

---

**Note**: This query was added in Elasticsearch 7.13+ and the JavaScript implementation has been available, but TypeScript definitions were missing.
